### PR TITLE
bugfix: fixing bug where generateUUID function appears when doing --last

### DIFF
--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -705,6 +705,7 @@ def generateUUID Unit: Result String Error =
         | setPlanLabel "rsc: generate client uuid"
         | setPlanPersistence Once # Exactly one UUID per wake invocation
         | runJobWith localRunner
+        | setJobInspectVisibilityHidden
 
     require True = isJobOk uuidJob
     else failWithError "failed to generate UUID for Wake invocation."

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -729,13 +729,13 @@ def readTmpFile (pathStr: String): Result String Error =
         Fail f -> Fail (makeError f)
 
 export def guardRemoteCacheDisabled Unit: Result Unit Error =
+    # If the file doesn't exist then we are not disabled
+    require Pass writtenUuid = readTmpFile disableCacheFilePath
+    else Pass Unit
+
     require Pass currentWakeUuid = generateUUID Unit
 
-    def isRemoteCacheDisabled Unit = match (readTmpFile disableCacheFilePath)
-        Pass writtenUuid -> writtenUuid ==* currentWakeUuid
-        Fail _ -> False
-
-    require False = isRemoteCacheDisabled Unit
+    require True = writtenUuid !=* currentWakeUuid
     else failWithError cascadeTimeoutErrorMessage
 
     Pass Unit


### PR DESCRIPTION
This PR fixes the bug where when enabling rsc and running a wake command exposes the `generateUUID` function call when it should be hidden.

Before:
```
[aquazi@pe01 federation]$ wake --init .
[aquazi@pe01 federation]$ wake -x 'Unit'
Unit
[aquazi@pe01 federation]$ wake --last
# rsc: generate client uuid (17)
$ date +%s%N
1745341573150093718
```

After:
```
[aquazi@pe01 wake]$ ./bin/wake -x 'Unit'
Unit
[aquazi@pe01 wake]$ ./bin/wake --last
No jobs matched query
[aquazi@pe01 wake]$ 
```

The generateUUID function is required to run to check against the sentinel disable cache file to verify if the RSC should be disabled or not, in `guardRemoteCacheDisabled`. This PR also restructures `guardRemoteCacheDisabled` so that `generateUUID` is only called when necessary (only if the disabled file exists) instead of being called by default