### PR TITLE
Fix performance issue of wake --failed related to runner failures

### DIFF
--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -226,7 +226,8 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       "  runner_status integer not null default 0);"  // 0=success, non-zero=failure
       "create index if not exists job on jobs(directory, commandline, environment, stdin, "
       "signature, keep, job_id, stat_id);"
-      "create index if not exists runner_status_idx on jobs(runner_status) WHERE runner_status <> 0;"
+      "create index if not exists runner_status_idx on jobs(runner_status) WHERE runner_status <> "
+      "0;"
       "create index if not exists jobstats on jobs(stat_id);"
       "create table if not exists filetree("
       "  tree_id  integer primary key autoincrement,"


### PR DESCRIPTION
With the addition of `runner_status` to the `jobs` table on https://github.com/sifiveinc/wake/pull/1695, I noticed that there was significant delay in querying for failed jobs using `wake --failed` for larger wake.db's. This PR fixes this issue by also indexing on `runner_status` and adding it to the core subtable so that the database can query without checking every single row on the jobs table.