### PR TITLE
Fix runner reporting related bugs

### DIFF
--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -96,10 +96,11 @@ export def primJobLaunch (job: Job) (jobKey: JobKey) (usage: Usage): Unit =
 
 # Complete a job before launch with userland defined failure
 export def primJobFailLaunch (job: Job) (error: Error): Unit =
-    # report the error as a runner error
+    def _ = (\_ \_ prim "job_fail_launch") job error
+
     def _ = unsafe_reportJobRunnerFailure job (error.getErrorCause) 1
 
-    (\_ \_ prim "job_fail_launch") job error
+    Unit
 
 # Wrap `primJobFailLaunch` in the type signature required to satisfy `rmapFail`, for cases where
 # a runner fails *before* delegating to `localRunner` or anything else which calls `primJobLaunch`.

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -97,7 +97,6 @@ export def primJobLaunch (job: Job) (jobKey: JobKey) (usage: Usage): Unit =
 # Complete a job before launch with userland defined failure
 export def primJobFailLaunch (job: Job) (error: Error): Unit =
     def _ = (\_ \_ prim "job_fail_launch") job error
-
     def _ = unsafe_reportJobRunnerFailure job (error.getErrorCause) 1
 
     Unit

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -2071,7 +2071,7 @@ void prim_register_job(JobTable *jobtable, PrimMap &pmap) {
   // Get's the stdout/stderr of a job
   prim_register(pmap, "job_output", prim_job_output, type_job_output, PRIM_PURE);
 
-  // Get's the stdout/stderr/runner_out/runner_err of a job
+  // Get's the runner_out/runner_err of a job
   prim_register(pmap, "job_runner_output", prim_job_runner_output, type_job_output, PRIM_PURE);
 
   // Reports a runner error for a job


### PR DESCRIPTION
This PR addresses two bugs related to the runner reporting PR: https://github.com/sifiveinc/wake/pull/1695

1. Bug related to `primJobFailLaunch`: In the initial implementation of this function to incorporate runner related reporting before a job launch, the function would hit the assertion `Requirement job->state == 0 failed at src/runtime/job.cpp:1213` because the runtime C++ prim `job_fail_launch` expects that the job state machine execution state to be empty, however that is not the case as the call to `unsafe_reportJobRunnerError` sets the `job->state = RUNNER_ERROR`. The fix to this is to reorder the calls so that this assertion is not hit. 
2. Bug related to child processes inheriting fd 3/4 (which are for runner_err/output) and not closing them, which causes Wake to hang during polling in certain race conditions. This PR addresses this by making sure to clean up fd 3/4 when a process exits, and signaling to the Wake runtime that it is done with those file descriptors for any job dependent to it.