### PR TITLE
Add wake.db migration tool

### DIFF
--- a/.wakemanifest
+++ b/.wakemanifest
@@ -58,6 +58,7 @@ tools/tools.wake
 tools/wakebox/wakebox.wake
 tools/wake-format/wake-format.wake
 tools/wake-hash/hash.wake
+tools/wake-migrate/wake-migrate.wake
 tools/wake-unit/wake-unit.wake
 tools/wake/wake.wake
 vendor/blake2/blake2.wake

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 	rm -rf .build/* bin/* lib/wake/* */*.o */*/*.o src/json/jlexer.cpp src/parser/lexer.cpp src/parser/parser.cpp src/parser/parser.h src/version.h wake.db
 	touch bin/stamp lib/wake/stamp
 
-wake.db:	bin/wake bin/wakebox lib/wake/fuse-waked lib/wake/shim-wake lib/wake/wake-hash
+wake.db:	bin/wake bin/wakebox lib/wake/fuse-waked lib/wake/shim-wake lib/wake/wake-hash bin/wake-migrate
 	test -f $@ || ./bin/wake --init .
 
 install:	all
@@ -109,6 +109,9 @@ lib/wake/shim-wake:	tools/shim-wake/main.o vendor/blake2/blake2b-ref.o src/wcl/f
 
 lib/wake/wake-hash: tools/wake-hash/main.o vendor/blake2/blake2b-ref.o $(COMMON_OBJS)
 	$(CXX) $(CFLAGS) -o $@ $^ $(LOCAL_CFLAGS) $(CXX_VERSION) $(LDFLAGS) $(CORE_LDFLAGS)
+
+bin/wake-migrate: tools/wake-migrate/main.o $(COMMON_OBJS)
+	$(CXX) $(CFLAGS) -o $@ $^ $(LOCAL_CFLAGS) $(CXX_VERSION) $(LDFLAGS) $(CORE_LDFLAGS) -lsqlite3
 
 %.o:	%.cpp	$(filter-out src/parser/parser.h,$(wildcard */*/*.h)) | src/parser/parser.h
 	$(CXX) $(CFLAGS) $(LOCAL_CFLAGS) $(CORE_CFLAGS) $(CXX_VERSION) -o $@ -c $<

--- a/build.wake
+++ b/build.wake
@@ -98,6 +98,7 @@ def targets =
     buildBSP,
     (bootstrapTarget buildLSP),
     buildWakeFormat,
+    buildWakeMigrate,
     (bootstrapTarget buildJobCache),
     Nil
 

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -34,11 +34,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include "schema.h"
 #include "status.h"
 #include "wcl/iterator.h"
-
-// Increment every time the database schema changes
-#define SCHEMA_VERSION "8"
 
 #define VISIBLE 0
 #define INPUT 1
@@ -173,86 +171,7 @@ static int schema_cb(void *data, int columns, char **values, char **labels) {
 std::string Database::open(bool wait, bool memory, bool tty) {
   if (imp->db) return "";
   // Increment the SCHEMA_VERSION every time the below string changes.
-  const char *schema_sql =
-      "pragma auto_vacuum=incremental;"
-      "pragma journal_mode=wal;"
-      "pragma synchronous=0;"
-      "pragma locking_mode=exclusive;"
-      "pragma foreign_keys=on;"
-      "create table if not exists entropy("
-      "  row_id integer primary key autoincrement,"
-      "  seed   integer not null);"
-      "update entropy set seed=0 where 0;"  // "write" to acquire exclusive lock
-      "create table if not exists schema("
-      "  version integer primary key);"
-      "create table if not exists runs("
-      "  run_id  integer primary key autoincrement,"
-      "  time    integer not null,"
-      "  cmdline text    not null);"
-      "create table if not exists files("
-      "  file_id  integer primary key,"
-      "  path     text    not null,"
-      "  hash     text    not null,"
-      "  modified integer not null);"
-      "create unique index if not exists filenames on files(path);"
-      "create table if not exists stats("
-      "  stat_id    integer primary key autoincrement,"
-      "  hashcode   integer not null,"  // on collision, prefer largest stat_id (ie: newest)
-      "  status     integer not null,"
-      "  runtime    real    not null,"
-      "  cputime    real    not null,"
-      "  membytes   integer not null,"
-      "  ibytes     integer not null,"
-      "  obytes     integer not null,"
-      "  pathtime   real);"
-      "create index if not exists stathash on stats(hashcode);"
-      "create table if not exists jobs("
-      "  job_id      integer primary key autoincrement,"
-      "  run_id      integer not null references runs(run_id),"
-      "  use_id      integer not null references runs(run_id),"
-      "  label       text    not null,"
-      "  directory   text    not null,"
-      "  commandline blob    not null,"
-      "  environment blob    not null,"
-      "  stdin       text    not null,"  // might point outside the workspace
-      "  signature   integer not null,"  // hash(FnInputs, FnOutputs, Resources, Keep)
-      "  stack       blob    not null,"
-      "  stat_id     integer references stats(stat_id),"  // null if unmerged
-      "  starttime   integer not null default 0,"
-      "  endtime     integer not null default 0,"
-      "  keep        integer not null default 0,"
-      "  stale       integer not null default 0,"     // 0=false, 1=true
-      "  is_atty     integer not null default 0,"     // 0=false, 1=true
-      "  runner_status integer not null default 0);"  // 0=success, non-zero=failure
-      "create index if not exists job on jobs(directory, commandline, environment, stdin, "
-      "signature, keep, job_id, stat_id);"
-      "create index if not exists runner_status_idx on jobs(runner_status) WHERE runner_status <> "
-      "0;"
-      "create index if not exists jobstats on jobs(stat_id);"
-      "create table if not exists filetree("
-      "  tree_id  integer primary key autoincrement,"
-      "  access   integer not null,"  // 0=visible, 1=input, 2=output
-      "  job_id   integer not null references jobs(job_id) on delete cascade,"
-      "  file_id  integer not null references files(file_id),"
-      "  unique(job_id, access, file_id) on conflict ignore);"
-      "create index if not exists filesearch on filetree(file_id, access, job_id);"
-      "create table if not exists log("
-      "  log_id     integer primary key autoincrement,"
-      "  job_id     integer not null references jobs(job_id) on delete cascade,"
-      "  descriptor integer not null,"  // 1=stdout, 2=stderr, 3=runner_out, 4=runner_err
-      "  seconds    real    not null,"  // seconds after job start
-      "  output     text    not null);"
-      "create index if not exists logorder on log(job_id, descriptor, log_id);"
-      "create table if not exists tags("
-      "  job_id  integer not null references jobs(job_id) on delete cascade,"
-      "  uri     text,"
-      "  content text,"
-      "  unique(job_id, uri) on conflict replace);"
-      "create table if not exists unhashed_files("
-      "  unhashed_file_id integer primary key autoincrement,"
-      "  job_id integer not null references jobs(job_id) on delete cascade,"
-      "  path             text not null);"
-      "create index if not exists unhashed_outputs on unhashed_files(job_id);";
+  const char *schema_sql = WAKE_SCHEMA_SQL;
 
   bool waiting = false;
   int ret;
@@ -320,7 +239,8 @@ std::string Database::open(bool wait, bool memory, bool tty) {
       close_db(imp.get());
       return db_ver > atoi(SCHEMA_VERSION)
                  ? "wake.db was created by a newer version of Wake; please upgrade Wake."
-                 : "wake.db was created by an older version of Wake; please remove it.";
+                 : "wake.db was created by an older version of Wake; please remove it or run "
+                   "'wake-migrate wake.db' to upgrade it.";
     }
 
     char *fail = nullptr;
@@ -349,7 +269,8 @@ std::string Database::open(bool wait, bool memory, bool tty) {
         break;
       } else {
         close_db(imp.get());
-        return "produced by an incompatible version of wake; please remove it.";
+        return "produced by an incompatible version of wake; please remove it or run 'wake-migrate "
+               "wake.db' to upgrade it.";
       }
     }
 

--- a/src/runtime/schema.h
+++ b/src/runtime/schema.h
@@ -1,0 +1,93 @@
+#ifndef WAKE_SCHEMA_H
+#define WAKE_SCHEMA_H
+
+#define SCHEMA_VERSION "8"
+
+// Increment the SCHEMA_VERSION every time the below string changes.
+// Also add migrations to the wake-migration tool if needed.
+inline const char* getWakeSchemaSQL() {
+  return "pragma auto_vacuum=incremental;"
+         "pragma journal_mode=wal;"
+         "pragma synchronous=0;"
+         "pragma locking_mode=exclusive;"
+         "pragma foreign_keys=on;"
+         "create table if not exists entropy("
+         "  row_id integer primary key autoincrement,"
+         "  seed   integer not null);"
+         "update entropy set seed=0 where 0;"  // "write" to acquire exclusive lock
+         "create table if not exists schema("
+         "  version integer primary key);"
+         "create table if not exists runs("
+         "  run_id  integer primary key autoincrement,"
+         "  time    integer not null,"
+         "  cmdline text    not null);"
+         "create table if not exists files("
+         "  file_id  integer primary key,"
+         "  path     text    not null,"
+         "  hash     text    not null,"
+         "  modified integer not null);"
+         "create unique index if not exists filenames on files(path);"
+         "create table if not exists stats("
+         "  stat_id    integer primary key autoincrement,"
+         "  hashcode   integer not null,"  // on collision, prefer largest stat_id (ie: newest)
+         "  status     integer not null,"
+         "  runtime    real    not null,"
+         "  cputime    real    not null,"
+         "  membytes   integer not null,"
+         "  ibytes     integer not null,"
+         "  obytes     integer not null,"
+         "  pathtime   real);"
+         "create index if not exists stathash on stats(hashcode);"
+         "create table if not exists jobs("
+         "  job_id      integer primary key autoincrement,"
+         "  run_id      integer not null references runs(run_id),"
+         "  use_id      integer not null references runs(run_id),"
+         "  label       text    not null,"
+         "  directory   text    not null,"
+         "  commandline blob    not null,"
+         "  environment blob    not null,"
+         "  stdin       text    not null,"  // might point outside the workspace
+         "  signature   integer not null,"  // hash(FnInputs, FnOutputs, Resources, Keep)
+         "  stack       blob    not null,"
+         "  stat_id     integer references stats(stat_id),"  // null if unmerged
+         "  starttime   integer not null default 0,"
+         "  endtime     integer not null default 0,"
+         "  keep        integer not null default 0,"
+         "  stale       integer not null default 0,"     // 0=false, 1=true
+         "  is_atty     integer not null default 0,"     // 0=false, 1=true
+         "  runner_status integer not null default 0);"  // 0=success, non-zero=failure
+         "create index if not exists job on jobs(directory, commandline, environment, stdin, "
+         "signature, keep, job_id, stat_id);"
+         "create index if not exists runner_status_idx on jobs(runner_status) WHERE runner_status "
+         "<> "
+         "0;"
+         "create index if not exists jobstats on jobs(stat_id);"
+         "create table if not exists filetree("
+         "  tree_id  integer primary key autoincrement,"
+         "  access   integer not null,"  // 0=visible, 1=input, 2=output
+         "  job_id   integer not null references jobs(job_id) on delete cascade,"
+         "  file_id  integer not null references files(file_id),"
+         "  unique(job_id, access, file_id) on conflict ignore);"
+         "create index if not exists filesearch on filetree(file_id, access, job_id);"
+         "create table if not exists log("
+         "  log_id     integer primary key autoincrement,"
+         "  job_id     integer not null references jobs(job_id) on delete cascade,"
+         "  descriptor integer not null,"  // 1=stdout, 2=stderr, 3=runner_out, 4=runner_err
+         "  seconds    real    not null,"  // seconds after job start
+         "  output     text    not null);"
+         "create index if not exists logorder on log(job_id, descriptor, log_id);"
+         "create table if not exists tags("
+         "  job_id  integer not null references jobs(job_id) on delete cascade,"
+         "  uri     text,"
+         "  content text,"
+         "  unique(job_id, uri) on conflict replace);"
+         "create table if not exists unhashed_files("
+         "  unhashed_file_id integer primary key autoincrement,"
+         "  job_id integer not null references jobs(job_id) on delete cascade,"
+         "  path             text not null);"
+         "create index if not exists unhashed_outputs on unhashed_files(job_id);";
+}
+
+#define WAKE_SCHEMA_SQL getWakeSchemaSQL()
+
+#endif

--- a/tools/wake-migrate/main.cpp
+++ b/tools/wake-migrate/main.cpp
@@ -1,0 +1,330 @@
+
+#include <sqlite3.h>
+#include <unistd.h>
+
+#include <cstring>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../../src/runtime/schema.h"
+
+static bool exec_sql(sqlite3* db, const char* sql) {
+  char* err = nullptr;
+  int rc = sqlite3_exec(db, sql, nullptr, nullptr, &err);
+  if (rc != SQLITE_OK) {
+    std::cerr << "SQL error: " << (err ? err : "(null)") << std::endl;
+    if (err) sqlite3_free(err);
+    return false;
+  }
+  return true;
+}
+
+static bool run_wake_schema(sqlite3* db) {
+  char* err = nullptr;
+  if (sqlite3_exec(db, WAKE_SCHEMA_SQL, nullptr, nullptr, &err) != SQLITE_OK) {
+    std::cerr << "Failed to apply WAKE_SCHEMA_SQL: " << (err ? err : "(null)") << std::endl;
+    if (err) sqlite3_free(err);
+    return false;
+  }
+  return true;
+}
+
+static int get_version(sqlite3* db) {
+  int version = 0;
+  sqlite3_stmt* stmt = nullptr;
+
+  // Try PRAGMA user_version first (preferred method)
+  if (sqlite3_prepare_v2(db, "PRAGMA user_version;", -1, &stmt, nullptr) == SQLITE_OK) {
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+      version = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+    if (version > 0) return version;
+  }
+
+  // Fallback to schema table for legacy databases
+  if (sqlite3_prepare_v2(db, "SELECT max(version) FROM schema;", -1, &stmt, nullptr) == SQLITE_OK) {
+    if (sqlite3_step(stmt) == SQLITE_ROW && sqlite3_column_type(stmt, 0) != SQLITE_NULL) {
+      version = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+  }
+
+  return version;
+}
+
+static bool set_version(sqlite3* db, int version) {
+  char pragma_buf[64];
+  snprintf(pragma_buf, sizeof(pragma_buf), "PRAGMA user_version=%d;", version);
+
+  // Set PRAGMA user_version
+  if (sqlite3_exec(db, pragma_buf, nullptr, nullptr, nullptr) != SQLITE_OK) {
+    return false;
+  }
+
+  // Insert/update schema table entry
+  std::string schema_sql =
+      "INSERT OR IGNORE INTO schema(version) VALUES(" + std::to_string(version) + ");";
+  return sqlite3_exec(db, schema_sql.c_str(), nullptr, nullptr, nullptr) == SQLITE_OK;
+}
+
+static bool backup_database(const std::string& db_path) {
+  std::string backup_path = db_path + ".backup";
+  std::string cmd = "cp '" + db_path + "' '" + backup_path + "'";
+
+  std::cout << "Creating backup: " << backup_path << std::endl;
+  return system(cmd.c_str()) == 0;
+}
+
+static bool has_column(sqlite3* db, const char* table, const char* column) {
+  sqlite3_stmt* stmt = nullptr;
+  std::string query = std::string("PRAGMA table_info(") + table + ");";
+  bool found = false;
+
+  if (sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, nullptr) == SQLITE_OK) {
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      const unsigned char* column_name = sqlite3_column_text(stmt, 1);
+      if (column_name && strcmp(reinterpret_cast<const char*>(column_name), column) == 0) {
+        found = true;
+        break;
+      }
+    }
+  }
+  sqlite3_finalize(stmt);
+  return found;
+}
+
+struct Migration {
+  int from_version;
+  int to_version;
+  std::function<bool(sqlite3*)> migrate_func;
+  std::string description;
+};
+
+// Migration registry - define all available migrations
+static std::vector<Migration> get_migrations() {
+  return {
+      // Version 6 -> 7: Add runner_status column to jobs table
+      {6, 7,
+       [](sqlite3* db) -> bool {
+         if (!has_column(db, "jobs", "runner_status")) {
+           const char* sql =
+               "ALTER TABLE jobs ADD COLUMN runner_status INTEGER NOT NULL DEFAULT 0;";
+           return exec_sql(db, sql);
+         }
+         return true;
+       },
+       "Add jobs.runner_status column"},
+
+      // Version 7 -> 8: Add partial index on runner_status for non-zero values
+      {7, 8,
+       [](sqlite3* db) -> bool {
+         const char* sql =
+             "CREATE INDEX IF NOT EXISTS runner_status_idx "
+             "ON jobs(runner_status) WHERE runner_status <> 0;";
+         return exec_sql(db, sql);
+       },
+       "Add runner_status partial index"},
+
+  };
+}
+
+// Apply a single migration step from from_version to to_version
+static bool apply_migrations(sqlite3* db, int from_version, int to_version) {
+  if (to_version != from_version + 1) {
+    std::cerr << "apply_migrations expects single-step migration, got " << from_version << " -> "
+              << to_version << std::endl;
+    return false;
+  }
+
+  std::vector<Migration> migrations = get_migrations();
+
+  // Find the specific migration for this version step
+  for (const auto& migration : migrations) {
+    if (migration.from_version == from_version && migration.to_version == to_version) {
+      std::cout << "Applying migration: " << migration.description << std::endl;
+      return migration.migrate_func(db);
+    }
+  }
+
+  std::cerr << "No migration found for " << from_version << " -> " << to_version << std::endl;
+  return false;
+}
+
+static bool run_integrity_check(sqlite3* db) {
+  // Enable foreign keys for complete integrity validation
+  if (!exec_sql(db, "PRAGMA foreign_keys=ON;")) return false;
+  sqlite3_stmt* st = nullptr;
+  if (sqlite3_prepare_v2(db, "PRAGMA integrity_check;", -1, &st, nullptr) != SQLITE_OK)
+    return false;
+  bool ok = false;
+  if (sqlite3_step(st) == SQLITE_ROW) {
+    const unsigned char* txt = sqlite3_column_text(st, 0);
+    ok = (txt && std::string(reinterpret_cast<const char*>(txt)) == "ok");
+  }
+  sqlite3_finalize(st);
+  return ok;
+}
+
+static bool migrate_via_copy(sqlite3* old_db, const std::string& db_path, int from_version,
+                             int to_version) {
+  std::string temp_path = db_path + ".migrated";
+  sqlite3* new_db = nullptr;
+
+  // Create temporary database for migration
+  if (sqlite3_open(temp_path.c_str(), &new_db) != SQLITE_OK) {
+    std::cerr << "Failed to create temp database: " << (new_db ? sqlite3_errmsg(new_db) : "(null)")
+              << std::endl;
+    if (new_db) sqlite3_close(new_db);
+    return false;
+  }
+
+  // Clone old database to new using SQLite backup API
+  bool clone_success = false;
+  sqlite3_backup* backup = sqlite3_backup_init(new_db, "main", old_db, "main");
+  if (backup) {
+    int result = sqlite3_backup_step(backup, -1);
+    clone_success = (result == SQLITE_DONE);
+    sqlite3_backup_finish(backup);
+  }
+
+  if (!clone_success) {
+    std::cerr << "Failed to clone database via backup API." << std::endl;
+    sqlite3_close(new_db);
+    return false;
+  }
+
+  // Apply stepwise migrations on the cloned database
+  int current_version = from_version;
+  while (current_version < to_version) {
+    int next_version = current_version + 1;
+
+    // Acquire write lock to begin transaction for this migration step
+    if (!exec_sql(new_db, "BEGIN IMMEDIATE;")) {
+      sqlite3_close(new_db);
+      return false;
+    }
+
+    std::cout << "Migrating " << current_version << " -> " << next_version << "..." << std::endl;
+
+    // Apply the migration
+    if (!apply_migrations(new_db, current_version, next_version)) {
+      std::cerr << "Migration step failed: " << current_version << " -> " << next_version
+                << std::endl;
+      exec_sql(new_db, "ROLLBACK;");
+      sqlite3_close(new_db);
+      return false;
+    }
+
+    // Update version stamps
+    if (!set_version(new_db, next_version)) {
+      std::cerr << "Failed to set version to " << next_version << std::endl;
+      exec_sql(new_db, "ROLLBACK;");
+      sqlite3_close(new_db);
+      return false;
+    }
+
+    // Commit this migration step
+    if (!exec_sql(new_db, "COMMIT;")) {
+      std::cerr << "Failed to commit migration step" << std::endl;
+      sqlite3_close(new_db);
+      return false;
+    }
+
+    current_version = next_version;
+  }
+
+  // Apply WAKE_SCHEMA_SQL to ensure all current schema objects exist
+  if (!run_wake_schema(new_db)) {
+    std::cerr << "Failed to apply WAKE_SCHEMA_SQL after migration" << std::endl;
+    sqlite3_close(new_db);
+    return false;
+  }
+
+  // Validate the migrated database
+  if (!run_integrity_check(new_db)) {
+    std::cerr << "PRAGMA integrity_check failed on migrated database" << std::endl;
+    sqlite3_close(new_db);
+    return false;
+  }
+
+  sqlite3_close(new_db);
+
+  // Swap the migrated database into place
+  std::string move_new_cmd = "mv '" + temp_path + "' '" + db_path + "'";
+
+  if (system(move_new_cmd.c_str()) != 0) {
+    std::cerr << "Failed to swap migrated database into place." << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <wake.db>" << std::endl;
+    return 1;
+  }
+
+  std::string db_path = argv[1];
+  sqlite3* db = nullptr;
+
+  if (sqlite3_open(db_path.c_str(), &db) != SQLITE_OK) {
+    std::cerr << "Cannot open database: " << sqlite3_errmsg(db) << std::endl;
+    return 1;
+  }
+
+  // Check current and target versions
+  int current_version = get_version(db);
+  int target_version = std::stoi(SCHEMA_VERSION);
+
+  std::cout << "Database version: " << current_version << std::endl;
+  std::cout << "Target version: " << target_version << std::endl;
+
+  if (current_version == target_version) {
+    std::cout << "Database is already up to date." << std::endl;
+    sqlite3_close(db);
+    return 0;
+  }
+
+  // Currently cannot migrate wake.db to an older version
+  if (current_version > target_version) {
+    std::cerr << "Database version (" << current_version
+              << ") is newer than this wake version supports (" << target_version << ")."
+              << std::endl;
+    std::cerr << "Please update wake or use a newer version." << std::endl;
+    sqlite3_close(db);
+    return 1;
+  }
+
+  if (current_version < 6) {
+    std::cerr << "Unsupported source version (" << current_version
+              << "). This tool only supports migration from version 6 and above." << std::endl;
+    sqlite3_close(db);
+    return 1;
+  }
+
+  // Create backup before migration
+  if (!backup_database(db_path)) {
+    std::cerr << "Failed to create backup. Aborting migration." << std::endl;
+    sqlite3_close(db);
+    return 1;
+  }
+
+  std::cout << "Migrating database from version " << current_version << " to " << target_version
+            << "..." << std::endl;
+
+  // Perform the migration
+  if (!migrate_via_copy(db, db_path, current_version, target_version)) {
+    std::cerr << "Migration failed." << std::endl;
+    sqlite3_close(db);
+    return 1;
+  }
+
+  std::cout << "Migration completed successfully." << std::endl;
+  sqlite3_close(db);
+  return 0;
+}

--- a/tools/wake-migrate/wake-migrate.wake
+++ b/tools/wake-migrate/wake-migrate.wake
@@ -1,0 +1,23 @@
+# Copyright 2025 SiFive, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of LICENSE.Apache2 along with
+# this software. If not, you may obtain a copy at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package build_wake
+
+from wake import _
+
+target buildWakeMigrate variant: Result (List Path) Error =
+    require Pass schemaHeader = source "src/runtime/schema.h"
+
+    tool @here (schemaHeader, Nil) variant "bin/wake-migrate" (util, wcl, sqlite3, Nil) Nil Nil

--- a/wake.spec.in
+++ b/wake.spec.in
@@ -37,6 +37,7 @@ mkdir -p %{buildroot}/var/cache/wake
 /usr/bin/wake-rsc-migration
 /usr/bin/wake-rsc-tool
 /usr/bin/wake-format
+/usr/bin/wake-migrate
 /usr/bin/job-cache
 /usr/lib/wake
 /usr/share/wake


### PR DESCRIPTION
Added the `wake-migration` tool so that users can now easily update and migrate their wake.db whenever wake releases have database version upgrades/schema changes without having to delete their current wake db instance.