### PR TITLE
Add content_hash field to verify cached blobs when downloaded

### DIFF
--- a/rust/entity/src/blob.rs
+++ b/rust/entity/src/blob.rs
@@ -12,6 +12,7 @@ pub struct Model {
     pub size: i64,
     pub created_at: DateTime,
     pub updated_at: DateTime,
+    pub content_hash: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/rust/migration/src/lib.rs
+++ b/rust/migration/src/lib.rs
@@ -16,6 +16,7 @@ mod m20240805_163520_create_blob_id_fk_indexes;
 mod m20240809_213440_add_job_audit_table;
 mod m20240819_193352_add_output_indexes;
 mod m20240919_214610_add_hidden_to_output_dir;
+mod m20250900_000000_add_content_hash_to_blob;
 
 pub struct Migrator;
 
@@ -39,6 +40,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240809_213440_add_job_audit_table::Migration),
             Box::new(m20240819_193352_add_output_indexes::Migration),
             Box::new(m20240919_214610_add_hidden_to_output_dir::Migration),
+            Box::new(m20250900_000000_add_content_hash_to_blob::Migration),
         ]
     }
 }

--- a/rust/migration/src/m20250900_000000_add_content_hash_to_blob.rs
+++ b/rust/migration/src/m20250900_000000_add_content_hash_to_blob.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Blob::Table)
+                    .add_column(
+                        ColumnDef::new(Blob::ContentHash)
+                            .string()
+                            .not_null()
+                            .default("")
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Blob::Table)
+                    .drop_column(Blob::ContentHash)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(Iden)]
+enum Blob {
+    Table,
+    ContentHash,
+}

--- a/rust/migration/src/m20250900_000000_add_content_hash_to_blob.rs
+++ b/rust/migration/src/m20250900_000000_add_content_hash_to_blob.rs
@@ -14,7 +14,6 @@ impl MigrationTrait for Migration {
                         ColumnDef::new(Blob::ContentHash)
                             .string()
                             .not_null()
-                            .default("")
                     )
                     .to_owned(),
             )

--- a/rust/migration/src/m20250900_000000_add_content_hash_to_blob.rs
+++ b/rust/migration/src/m20250900_000000_add_content_hash_to_blob.rs
@@ -33,7 +33,7 @@ impl MigrationTrait for Migration {
     }
 }
 
-#[derive(Iden)]
+#[derive(DeriveIden)]
 enum Blob {
     Table,
     ContentHash,

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -528,6 +528,7 @@ mod tests {
             id: NotSet,
             created_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
             updated_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
+            content_hash: Set("0".into()),
             key: Set("InsecureKey".into()),
             size: Set(11),
             store_id: Set(store_id),

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -753,10 +753,12 @@ mod tests {
                 "output_symlinks": [],
                 "output_files":[],
                 "stdout_blob": {
+                    "content_hash": "0",
                     "id": blob_id,
                     "url": format!("test://{0}/InsecureKey", store_id),
                 },
                 "stderr_blob": {
+                    "content_hash": "0",
                     "id": blob_id,
                     "url": format!("test://{0}/InsecureKey", store_id),
                 },

--- a/rust/rsc/src/bin/rsc/main.rs
+++ b/rust/rsc/src/bin/rsc/main.rs
@@ -528,7 +528,7 @@ mod tests {
             id: NotSet,
             created_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
             updated_at: Set((Utc::now() - Duration::days(5)).naive_utc()),
-            content_hash: Set("0".into()),
+            content_hash: Set("fakeblobhash".into()),
             key: Set("InsecureKey".into()),
             size: Set(11),
             store_id: Set(store_id),
@@ -753,12 +753,12 @@ mod tests {
                 "output_symlinks": [],
                 "output_files":[],
                 "stdout_blob": {
-                    "content_hash": "0",
+                    "content_hash": "fakeblobhash",
                     "id": blob_id,
                     "url": format!("test://{0}/InsecureKey", store_id),
                 },
                 "stderr_blob": {
-                    "content_hash": "0",
+                    "content_hash": "fakeblobhash",
                     "id": blob_id,
                     "url": format!("test://{0}/InsecureKey", store_id),
                 },

--- a/rust/rsc/src/bin/rsc/read_job.rs
+++ b/rust/rsc/src/bin/rsc/read_job.rs
@@ -44,7 +44,6 @@ async fn resolve_blobs<T: ConnectionTrait>(
     const CHUNK_SIZE: usize = 50_000;
 
     let mut resolved_map = HashMap::new();
-
     for chunk in ids.chunks(CHUNK_SIZE) {
         // Fetch chunked blobs in a single query
         let blob_map: HashMap<Uuid, entity::blob::Model> = Blob::find()
@@ -112,7 +111,6 @@ pub async fn read_job(
                     tracing::info!(%hash, "Miss");
                     return Ok(None);
                 };
-
                 let output_files = matching_job.find_related(output_file::Entity).all(txn).await?;
                 let output_symlinks = matching_job.find_related(output_symlink::Entity).all(txn).await?;
                 let output_dirs = matching_job.find_related(output_dir::Entity).all(txn).await?;
@@ -121,7 +119,6 @@ pub async fn read_job(
             })
         })
         .await;
-
     let hash_copy = hash_for_spawns.clone();
     let Some((matching_job, output_files, output_symlinks, output_dirs)) = fetch_result.ok().flatten() else {
         tokio::spawn(async move {

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -253,7 +253,6 @@ pub enum ReadJobResponse {
         output_files: Vec<ResolvedBlobFile>,
         stdout_blob: ResolvedBlob,
         stderr_blob: ResolvedBlob,
-        content_hash: String,
         status: i32,
         runtime: f64,
         cputime: f64,

--- a/rust/rsc/src/bin/rsc/types.rs
+++ b/rust/rsc/src/bin/rsc/types.rs
@@ -219,6 +219,7 @@ impl JobKeyHash for AllowJobPayload {
 pub struct PostBlobResponsePart {
     pub id: Uuid,
     pub name: String,
+    pub content_hash: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -232,6 +233,7 @@ pub enum PostBlobResponse {
 pub struct ResolvedBlob {
     pub id: Uuid,
     pub url: String,
+    pub content_hash: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -251,6 +253,7 @@ pub enum ReadJobResponse {
         output_files: Vec<ResolvedBlobFile>,
         stdout_blob: ResolvedBlob,
         stderr_blob: ResolvedBlob,
+        content_hash: String,
         status: i32,
         runtime: f64,
         cputime: f64,

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -120,8 +120,9 @@ export def setBody (body: String): HttpRequest => HttpRequest =
 export def addFormData (name: String) (value: Path) (contentType: Option String): HttpRequest => HttpRequest =
     unsafe_addFormData name (HttpFormDataFile value.getPathName) contentType
 
-# Adds a string to the request's form data
-export def addStringFormData (name: String) (value: String) (contentType: Option String): HttpRequest => HttpRequest =
+# Adds a string to the request's form data. This is marked unsafe as it is the callers responsibility to ensure the string
+# is shell safe.
+export def unsafe_addStringFormData (name: String) (value: String) (contentType: Option String): HttpRequest => HttpRequest =
     unsafe_addFormData name (HttpFormDataString value) contentType
 
 # Adds form data content to the request's form data field.

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -120,10 +120,9 @@ export def setBody (body: String): HttpRequest => HttpRequest =
 export def addFormData (name: String) (value: Path) (contentType: Option String): HttpRequest => HttpRequest =
     unsafe_addFormData name (HttpFormDataFile value.getPathName) contentType
 
-# Adds a string to the request's form data. This is marked unsafe as it is the callers responsibility to ensure the string
-# is shell safe.
-export def unsafe_addStringFormData (name: String) (value: String) (contentType: Option String): HttpRequest => HttpRequest =
-    unsafe_addFormData name (HttpFormDataString value) contentType
+# Adds a string to the request's form data. It is the callers responsibility to ensure the string is shell safe.
+export def addStringFormData (name: String) (value: String): HttpRequest => HttpRequest =
+    unsafe_addFormData name (HttpFormDataString value) None
 
 # Adds form data content to the request's form data field.
 #
@@ -226,7 +225,7 @@ def makeCurlCmd ((HttpRequest url method headers body formData maxTime connectTi
 
         match content
             HttpFormDataFile file -> "--form", "{name}=@\"{file}\"{typeFlag}", Nil
-            HttpFormDataString str -> "--form", "{name}={str}{typeFlag}", Nil
+            HttpFormDataString str -> "--form-string", "{name}={str}", Nil
 
     def bodyToCurlFlag body =
         require True = body.strlen >= 5000

--- a/share/wake/lib/system/http.wake
+++ b/share/wake/lib/system/http.wake
@@ -21,18 +21,25 @@ tuple HttpHeader =
     Name: String
     Value: String
 
-# A form data entry. It consists of a user defined name and a file on disk to upload.
+# A form data entry. It consists of a user defined name and either a file on disk or string to upload.
 #
-# Note: while raw strings are generally accepted as http form data the actual encoding of the
-# string results in shell escape headaches. Strings should be written to a file before upload.
 tuple HttpFormData =
     Name: String
+    # Either a file path or string content
+    Content: HttpFormDataContent
+    # The optional Content-Type field of the specific form entry
+    ContentType: Option String
+
+# The content of form data - either a file or string
+export data HttpFormDataContent =
     # This file is deliberately left unhashed to avoid multiple jobs outputting the same file
     # in the fullness of time it should be converted to a Path. This library is careful to not
     # claim or otherwise convert it to a Path as it should be done by the caller when possible
-    File: String
-    # The optional Content-Type field of the specific form entry. The field is not set when None
-    ContentType: Option String
+    HttpFormDataFile String
+    # Note: while raw strings are generally accepted as http form data the actual encoding of the
+    # string results in shell escape headaches. Caller is responsible for ensuring the string handles
+    # the escaping correctly.
+    HttpFormDataString String
 
 # The description of a http request to send to a web server.
 tuple HttpRequest =
@@ -111,14 +118,18 @@ export def setBody (body: String): HttpRequest => HttpRequest =
 
 # Adds a named file to the requests form data.
 export def addFormData (name: String) (value: Path) (contentType: Option String): HttpRequest => HttpRequest =
-    unsafe_addFormData name value.getPathName contentType
+    unsafe_addFormData name (HttpFormDataFile value.getPathName) contentType
 
-# Adds a named file to the request's form data from an unhashed file.
+# Adds a string to the request's form data
+export def addStringFormData (name: String) (value: String) (contentType: Option String): HttpRequest => HttpRequest =
+    unsafe_addFormData name (HttpFormDataString value) contentType
+
+# Adds form data content to the request's form data field.
 #
 # This is a restricted function and should be reserved for advanced use only
-export def unsafe_addFormData (name: String) (value: String) (contentType: Option String): HttpRequest => HttpRequest =
+export def unsafe_addFormData (name: String) (content: HttpFormDataContent) (contentType: Option String): HttpRequest => HttpRequest =
     def setOrAppend field =
-        def entry = HttpFormData name value contentType
+        def entry = HttpFormData name content contentType
 
         match field
             Some formDatas -> Some (entry, formDatas)
@@ -207,9 +218,14 @@ def methodToString = match _
 def makeCurlCmd ((HttpRequest url method headers body formData maxTime connectTime): HttpRequest) (extraFlags: List String): Result (List String) Error =
     def headerToCurlFlag (HttpHeader name value) = "--header", "{name}:{value}", Nil
 
-    def formDataToCurlFlag (HttpFormData name file contentType) = match contentType
-        Some ct -> "--form", "{name}=@\"{file}\";type={ct}", Nil
-        None -> "--form", "{name}=@\"{file}\"", Nil
+    def formDataToCurlFlag (HttpFormData name content contentType) =
+        def typeFlag = match contentType
+            Some ct -> ";type={ct}"
+            None -> ""
+
+        match content
+            HttpFormDataFile file -> "--form", "{name}=@\"{file}\"{typeFlag}", Nil
+            HttpFormDataString str -> "--form", "{name}={str}{typeFlag}", Nil
 
     def bodyToCurlFlag body =
         require True = body.strlen >= 5000

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -63,8 +63,10 @@ tuple CacheSearchRequest =
 tuple CacheSearchBlob =
     # The id of the blob on the remote server
     Id: String
-    # The uri where the blob may be downloaded from. Not guaranteed to be http/https
+    # The uri where the blob may be downloaded from
     Uri: String
+    # The content hash of the blob used for verification
+    ContentHash: String
 
 # A file backed by a blob that a cached job created
 tuple CacheSearchOutputFile =
@@ -343,8 +345,9 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
     def contentType = contentTypeFromSize value.strlen
 
     require Pass temp = writeTempFile name value
+    def fileHash = temp.getPathHash
 
-    uploadBlobRequest api (addFormData name temp contentType)
+    uploadBlobRequest api (addFormDataWithHash name temp.getPathName contentType fileHash)
 
 # rscApiPostFileBlob: Posts a named file on disk to the remote server defined by *api*
 #                     then returns the id associated to the blob. Requires authorization.
@@ -363,7 +366,10 @@ export def rscApiPostFileBlob (name: String) (file: String) (api: RemoteCacheApi
         Pass (Stat _ _ size) -> contentTypeFromSize size
         Fail _ -> None
 
-    uploadBlobRequest api (unsafe_addFormData name file contentType)
+    # retrieve the hash of the file being uploaded
+    require Pass fileHash = rsciHashFile file
+
+    uploadBlobRequest api (addFormDataWithHash name file contentType fileHash)
 
 # rscApiPostJob: Posts a job defined by *req* to the remote cache server. Requires authorization.
 #
@@ -626,22 +632,28 @@ def resolveUriResponse (dbSchemeFn: (String => String => Result a Error)) (fileS
 # ```
 #  rscApiGetStringBlob (RemoteCacheBlob "asdf" "https://...") = Pass "foo\nbar\nbat"
 # ```
-export def rscApiGetStringBlob ((CacheSearchBlob _ uri): CacheSearchBlob): Result String Error =
+export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob): Result String Error =
     def resolveStringFileScheme scheme path =
         buildHttpRequest "{scheme}://{path}"
         | setMethod HttpMethodGet
         | makeRequest
         |< getHttpResponseBody
 
-    uri
-    | resolveUriResponse resolveDbScheme resolveStringFileScheme
+    require Pass content = uri | resolveUriResponse resolveDbScheme resolveStringFileScheme
+
+    # Verify content hash if provided
+    def actualHash = hashString content
+    require True = actualHash ==* contentHash
+    else failWithError "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
+
+    Pass content
 
 # rscApiGetFileBlob: Downloads a blob to *path* with *mode* permisssions and return *path*
 #
 # ```
 #  rscApiGetFileBlob (RemoteCacheBlob "asdf" "https://...") "foo/bar" 0644 = Pass "foo/bar"
 # ```
-export def rscApiGetFileBlob ((CacheSearchBlob blobId uri): CacheSearchBlob) (path: String) (mode: Integer): Result String Error =
+export def rscApiGetFileBlob ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob) (path: String) (mode: Integer): Result String Error =
     def resolveDbSchemeToFile scheme path =
         resolveDbScheme scheme path
         |> writeTempFile "rsc.output_file.blob.{blobId}"
@@ -652,6 +664,11 @@ export def rscApiGetFileBlob ((CacheSearchBlob blobId uri): CacheSearchBlob) (pa
         | makeBinaryRequest
 
     require Pass blobPath = (uri | resolveUriResponse resolveDbSchemeToFile resolveBlobFileScheme)
+
+    # Verify content hash if provided
+    require Pass actualHash = rsciHashFile blobPath.getPathName
+    require True = actualHash ==* contentHash
+    else failWithError "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
 
     def fixupScript =
         """
@@ -832,6 +849,12 @@ def uploadBlobRequest (api: RemoteCacheApi) (setBlob: HttpRequest => HttpRequest
 
     Pass id
 
+# Helper to add form data with hash
+def addFormDataWithHash (name: String) (file: String) (contentType: Option String) (hash: String) (req: HttpRequest): HttpRequest =
+    req
+    | unsafe_addFormData name file contentType
+    | unsafe_addFormData "content_hash" hash None
+
 # Converts a CacheSearchRequest to JSON
 def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =
     def (CacheSearchRequest _label cmd cwd env hiddenInfo isAtty stdin visibleFiles) = req
@@ -962,7 +985,10 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
         require Pass (JString url) = jField v "url"
         else failWithError "rsc: JSON response has incorrect schema. '{v | format}' must have string key 'url'"
 
-        CacheSearchBlob id url
+        require Pass (JString contentHash) = jField v "content_hash"
+        else failWithError "rsc: JSON response has incorrect schema. '{v | format}' must have string key 'content_hash'"
+
+        CacheSearchBlob id url contentHash
         | Pass
 
     require Pass stdoutBlobF = jField json "stdout_blob"
@@ -1084,3 +1110,31 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
     obytes
     | Match
     | Pass
+
+def hashUsage =
+    Usage 0 0.0 0.1 0 0 0
+
+# RSC version of computing hashes for files, similar to Hashcode target in path.wake
+def rsciHashFile (file: String): Result String Error =
+    def hashPlan cmd =
+        Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun Nil hashUsage identity identity False
+
+    def hashJob =
+        hashPlan ("<hash>", file, Nil)
+        | setPlanLabel "rsc: compute hash for {file}"
+        | runJobWith localRunner
+        | setJobInspectVisibilityHidden
+
+    require True = hashJob.isJobOk
+    else failWithError "rsc: Failed to compute hash for file {file}"
+
+    require Pass stdout = hashJob.getJobStdout
+    else failWithError "rsc: Failed to get stdout for hash job"
+
+    def fileHash =
+        stdout
+        | extract `(.{64}).*`
+
+    match fileHash
+        (hash, Nil) -> Pass hash
+        _ -> failWithError "rsc: No hash found in output for file {file}"

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -63,7 +63,7 @@ tuple CacheSearchRequest =
 tuple CacheSearchBlob =
     # The id of the blob on the remote server
     Id: String
-    # The uri where the blob may be downloaded from
+    # The uri where the blob may be downloaded from. Not guaranteed to be http/https
     Uri: String
     # The content hash of the blob used for verification
     ContentHash: String
@@ -346,9 +346,8 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
     def hash = hashString value
 
     require Pass temp = writeTempFile name value
-    require Pass hashFile = writeTempFile "content_hash" hash
 
-    def setBlobFn = addFormDataWithHash name temp.getPathName contentType hashFile
+    def setBlobFn = addFormDataWithHash name temp.getPathName contentType hash
 
     uploadBlobRequest api setBlobFn
 
@@ -362,14 +361,16 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
 export def rscApiPostFileBlob (name: String) (file: String) (api: RemoteCacheApi): Result String Error =
     require Pass _ = guardRemoteCacheDisabled Unit
 
+    # We must use unsafe here since we cannot elevate *file* to a Path without either copying it
+    # or triggering the 'job output by multiple files' error.
+
     def contentType = match (unsafe_stat file)
         Pass (Stat _ _ size) -> contentTypeFromSize size
         Fail _ -> None
 
     require Pass hash = rsciHashFile file
-    require Pass hashFile = writeTempFile "content_hash" hash
 
-    def setBlobFn = addFormDataWithHash name file contentType hashFile
+    def setBlobFn = addFormDataWithHash name file contentType hash
 
     uploadBlobRequest api setBlobFn
 
@@ -867,10 +868,10 @@ def uploadBlobRequest (api: RemoteCacheApi) (setBlob: HttpRequest => HttpRequest
     Pass id
 
 # Helper to add form data with hash
-def addFormDataWithHash (name: String) (file: String) (contentType: Option String) (hashFile: Path) (req: HttpRequest): HttpRequest =
+def addFormDataWithHash (name: String) (file: String) (contentType: Option String) (hash: String) (req: HttpRequest): HttpRequest =
     req
-    | unsafe_addFormData name file contentType
-    | unsafe_addFormData "content_hash" hashFile.getPathName None
+    | unsafe_addFormData name (HttpFormDataFile file) contentType
+    | addStringFormData "content_hash" hash None
 
 # Converts a CacheSearchRequest to JSON
 def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -638,13 +638,17 @@ def resolveUriResponse (dbSchemeFn: (String => String => Result a Error)) (fileS
 export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob): Result String Error =
     def resolveStringFileScheme scheme path =
         def url = "{scheme}://{path}"
+
         require Pass binaryPath =
             buildHttpRequest url
             | setMethod HttpMethodGet
             | makeBinaryRequest
+
         read binaryPath
 
-    require Pass content = uri | resolveUriResponse resolveDbScheme resolveStringFileScheme
+    require Pass content =
+        uri
+        | resolveUriResponse resolveDbScheme resolveStringFileScheme
 
     def actualHash = hashString content
 
@@ -653,8 +657,11 @@ export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheS
         def _ =
             require True = shouldDebugRemoteCache Unit
 
-            def _ = breadcrumb "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
+            def _ =
+                breadcrumb "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
+
             True
+
         failWithError "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
 
     Pass content
@@ -678,15 +685,19 @@ export def rscApiGetFileBlob ((CacheSearchBlob blobId uri contentHash): CacheSea
 
     # Verify content hash if provided
     require Pass actualHash = rsciHashFile blobPath.getPathName
+
     require True = actualHash ==* contentHash
     else
         def _ =
             require True = shouldDebugRemoteCache Unit
 
-            def _ = breadcrumb "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
+            def _ =
+                breadcrumb "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
+
             True
 
-        failWithError "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
+        failWithError
+        "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
 
     def fixupScript =
         """
@@ -871,7 +882,8 @@ def uploadBlobRequest (api: RemoteCacheApi) (setBlob: HttpRequest => HttpRequest
 def addFormDataWithHash (name: String) (file: String) (contentType: Option String) (hash: String) (req: HttpRequest): HttpRequest =
     req
     | unsafe_addFormData name (HttpFormDataFile file) contentType
-    | addStringFormData "content_hash" hash None
+    # Since the hash string is in hex, it is safe to pass as a string to curl
+    | unsafe_addStringFormData "content_hash" hash None
 
 # Converts a CacheSearchRequest to JSON
 def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =
@@ -1004,7 +1016,9 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
         else failWithError "rsc: JSON response has incorrect schema. '{v | format}' must have string key 'url'"
 
         require Pass (JString contentHash) = jField v "content_hash"
-        else failWithError "rsc: JSON response has incorrect schema. '{v | format}' must have string key 'content_hash'"
+        else
+            failWithError
+            "rsc: JSON response has incorrect schema. '{v | format}' must have string key 'content_hash'"
 
         CacheSearchBlob id url contentHash
         | Pass

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -368,7 +368,7 @@ export def rscApiPostFileBlob (name: String) (file: String) (api: RemoteCacheApi
         Pass (Stat _ _ size) -> contentTypeFromSize size
         Fail _ -> None
 
-    require Pass hash = rsciHashFile file
+    require Pass hash = rscHashFile file
 
     def setBlobFn = addFormDataWithHash name file contentType hash
 
@@ -630,28 +630,8 @@ def resolveUriResponse (dbSchemeFn: (String => String => Result a Error)) (fileS
 
     schemeFn scheme path
 
-# rscApiGetStringBlob: Downloads a blob and returns the contents as a string
-#
-# ```
-#  rscApiGetStringBlob (RemoteCacheBlob "asdf" "https://...") = Pass "foo\nbar\nbat"
-# ```
-export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob): Result String Error =
-    def resolveStringFileScheme scheme path =
-        def url = "{scheme}://{path}"
-
-        require Pass binaryPath =
-            buildHttpRequest url
-            | setMethod HttpMethodGet
-            | makeBinaryRequest
-
-        read binaryPath
-
-    require Pass content =
-        uri
-        | resolveUriResponse resolveDbScheme resolveStringFileScheme
-
-    def actualHash = hashString content
-
+# Verifies that the actual hash matches the expected content hash
+def verifyBlobHash (blobId: String) (actualHash: String) (contentHash: String): Result Unit Error =
     require True = actualHash ==* contentHash
     else
         def _ =
@@ -663,6 +643,32 @@ export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheS
             True
 
         failWithError "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
+
+    Pass Unit
+
+# rscApiGetStringBlob: Downloads a blob and returns the contents as a string
+#
+# ```
+#  rscApiGetStringBlob (RemoteCacheBlob "asdf" "https://...") = Pass "foo\nbar\nbat"
+# ```
+export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob): Result String Error =
+    def resolveStringFileScheme scheme path =
+        def blobUrl = "{scheme}://{path}"
+
+        require Pass binaryPath =
+            buildHttpRequest blobUrl
+            | setMethod HttpMethodGet
+            | makeBinaryRequest
+
+        read binaryPath
+
+    require Pass content =
+        uri
+        | resolveUriResponse resolveDbScheme resolveStringFileScheme
+
+    def actualHash = hashString content
+
+    require Pass _ = verifyBlobHash blobId actualHash contentHash
 
     Pass content
 
@@ -684,20 +690,8 @@ export def rscApiGetFileBlob ((CacheSearchBlob blobId uri contentHash): CacheSea
     require Pass blobPath = (uri | resolveUriResponse resolveDbSchemeToFile resolveBlobFileScheme)
 
     # Verify content hash if provided
-    require Pass actualHash = rsciHashFile blobPath.getPathName
-
-    require True = actualHash ==* contentHash
-    else
-        def _ =
-            require True = shouldDebugRemoteCache Unit
-
-            def _ =
-                breadcrumb "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
-
-            True
-
-        failWithError
-        "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
+    require Pass actualHash = rscHashFile blobPath.getPathName
+    require Pass _ = verifyBlobHash blobId actualHash contentHash
 
     def fixupScript =
         """
@@ -883,7 +877,7 @@ def addFormDataWithHash (name: String) (file: String) (contentType: Option Strin
     req
     | unsafe_addFormData name (HttpFormDataFile file) contentType
     # Since the hash string is in hex, it is safe to pass as a string to curl
-    | unsafe_addStringFormData "content_hash" hash None
+    | addStringFormData "content_hash" hash
 
 # Converts a CacheSearchRequest to JSON
 def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =
@@ -1147,7 +1141,7 @@ def hashUsage =
     Usage 0 0.0 0.1 0 0 0
 
 # RSC version of computing hashes for files, similar to Hashcode target in path.wake
-def rsciHashFile (file: String): Result String Error =
+def rscHashFile (file: String): Result String Error =
     def hashPlan cmd =
         Plan "" cmd Nil Nil "." "" logNever logError logDebug ReRun Nil hashUsage identity identity False
 

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -343,11 +343,14 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
     require Pass _ = guardRemoteCacheDisabled Unit
 
     def contentType = contentTypeFromSize value.strlen
+    def hash = hashString value
 
     require Pass temp = writeTempFile name value
-    def fileHash = temp.getPathHash
+    require Pass hashFile = writeTempFile "content_hash" hash
 
-    uploadBlobRequest api (addFormDataWithHash name temp.getPathName contentType fileHash)
+    def setBlobFn = addFormDataWithHash name temp.getPathName contentType hashFile
+
+    uploadBlobRequest api setBlobFn
 
 # rscApiPostFileBlob: Posts a named file on disk to the remote server defined by *api*
 #                     then returns the id associated to the blob. Requires authorization.
@@ -359,17 +362,16 @@ export def rscApiPostStringBlob (name: String) (value: String) (api: RemoteCache
 export def rscApiPostFileBlob (name: String) (file: String) (api: RemoteCacheApi): Result String Error =
     require Pass _ = guardRemoteCacheDisabled Unit
 
-    # We must use unsafe here since we cannot elevate *file* to a Path without either copying it
-    # or triggering the 'job output by multiple files' error.
-
     def contentType = match (unsafe_stat file)
         Pass (Stat _ _ size) -> contentTypeFromSize size
         Fail _ -> None
 
-    # retrieve the hash of the file being uploaded
-    require Pass fileHash = rsciHashFile file
+    require Pass hash = rsciHashFile file
+    require Pass hashFile = writeTempFile "content_hash" hash
 
-    uploadBlobRequest api (addFormDataWithHash name file contentType fileHash)
+    def setBlobFn = addFormDataWithHash name file contentType hashFile
+
+    uploadBlobRequest api setBlobFn
 
 # rscApiPostJob: Posts a job defined by *req* to the remote cache server. Requires authorization.
 #
@@ -634,17 +636,25 @@ def resolveUriResponse (dbSchemeFn: (String => String => Result a Error)) (fileS
 # ```
 export def rscApiGetStringBlob ((CacheSearchBlob blobId uri contentHash): CacheSearchBlob): Result String Error =
     def resolveStringFileScheme scheme path =
-        buildHttpRequest "{scheme}://{path}"
-        | setMethod HttpMethodGet
-        | makeRequest
-        |< getHttpResponseBody
+        def url = "{scheme}://{path}"
+        require Pass binaryPath =
+            buildHttpRequest url
+            | setMethod HttpMethodGet
+            | makeBinaryRequest
+        read binaryPath
 
     require Pass content = uri | resolveUriResponse resolveDbScheme resolveStringFileScheme
 
-    # Verify content hash if provided
     def actualHash = hashString content
+
     require True = actualHash ==* contentHash
-    else failWithError "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
+    else
+        def _ =
+            require True = shouldDebugRemoteCache Unit
+
+            def _ = breadcrumb "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
+            True
+        failWithError "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
 
     Pass content
 
@@ -668,7 +678,14 @@ export def rscApiGetFileBlob ((CacheSearchBlob blobId uri contentHash): CacheSea
     # Verify content hash if provided
     require Pass actualHash = rsciHashFile blobPath.getPathName
     require True = actualHash ==* contentHash
-    else failWithError "rsc: Hash mismatch for blob {blobId}. Expected: {contentHash}, Got: {actualHash}"
+    else
+        def _ =
+            require True = shouldDebugRemoteCache Unit
+
+            def _ = breadcrumb "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
+            True
+
+        failWithError "rsc: Hash mismatch for blob {blobPath.getPathName}. Expected: {contentHash}, Got: {actualHash}"
 
     def fixupScript =
         """
@@ -850,10 +867,10 @@ def uploadBlobRequest (api: RemoteCacheApi) (setBlob: HttpRequest => HttpRequest
     Pass id
 
 # Helper to add form data with hash
-def addFormDataWithHash (name: String) (file: String) (contentType: Option String) (hash: String) (req: HttpRequest): HttpRequest =
+def addFormDataWithHash (name: String) (file: String) (contentType: Option String) (hashFile: Path) (req: HttpRequest): HttpRequest =
     req
     | unsafe_addFormData name file contentType
-    | unsafe_addFormData "content_hash" hash None
+    | unsafe_addFormData "content_hash" hashFile.getPathName None
 
 # Converts a CacheSearchRequest to JSON
 def getCacheSearchRequestJson (req: CacheSearchRequest): JValue =


### PR DESCRIPTION
In order to protect against cache poisoning of the blob store, this PR introduces the `content_hash` field that sends a blake2b hash of the contents of the output file blobs of a cached job to the RSC server for it to store in the DB, as a way for clients to check against the hash when downloading the blob from the store during a cache hit. 