### PR TITLE
Return full Job info even if the runner fails

### DIFF
--- a/share/wake/lib/system/io.wake
+++ b/share/wake/lib/system/io.wake
@@ -138,7 +138,7 @@ def writeRunner (content: String) =
     def primWrite (mode: Integer) (path: String) (content: String): Result String String =
         (\_ \_ \_ prim "write") mode path content
 
-    def run (job: Job) ((RunnerInput _ cmd vis _ _ _ _ _ predict _ fnInputs fnOutputs): RunnerInput): Result RunnerOutput Error =
+    def run (job: Job) ((RunnerInput _ cmd vis _ _ _ _ _ predict _ fnInputs fnOutputs): RunnerInput): RunnerOutput =
         # Command must be ("<write>", "-m", "{string mode}", "{string path}", Nil)
         require "<write>", "-m", smode, path, Nil = cmd
         else panic "writeImp violated command-line contract"
@@ -148,18 +148,24 @@ def writeRunner (content: String) =
 
         # Actually trigger the effects required by the job
         require Some mode = int smode
-        else failWithError "write {path}: Unable to convert mode to Integer ({smode})"
+        else
+            Some "write {path}: Unable to convert mode to Integer ({smode})".makeError
+            | RunnerOutput Nil Nil Nil emptyUsage
 
         require True = mode >= 0 && mode <= 0x1ff
-        else failWithError "write {path}: Invalid mode ({strOctal mode})"
+        else
+            Some "write {path}: Invalid mode ({strOctal mode})".makeError
+            | RunnerOutput Nil Nil Nil emptyUsage
 
         def writeTask = primWrite mode path content
 
         # Wait for the virtual job to complete
-        require Pass reality = job.getJobReality
+        def Pair usage runnerError = match job.getJobReality
+            Fail err -> Pair emptyUsage (Some err)
+            Pass reality -> Pair reality None
 
         match writeTask
-            Fail f -> failWithError f
+            Fail msg -> RunnerOutput Nil Nil Nil usage (Some msg.makeError)
             Pass path ->
                 def fileInputs =
                     vis
@@ -169,8 +175,7 @@ def writeRunner (content: String) =
                 def cleanable = (path, Nil)
                 def fileOutputs = fnOutputs cleanable
 
-                RunnerOutput fileInputs fileOutputs cleanable reality 0
-                | Pass
+                RunnerOutput fileInputs fileOutputs cleanable usage runnerError
 
     makeRunner "write" run
 
@@ -285,7 +290,7 @@ def mkdirRunner: Runner =
     def primMkdir (mode: Integer) (path: String): Result String String =
         (\_ \_ prim "mkdir") mode path
 
-    def run (job: Job) ((RunnerInput _ cmd vis _ _ _ _ _ predict _ fnInputs fnOutputs): RunnerInput): Result RunnerOutput Error =
+    def run (job: Job) ((RunnerInput _ cmd vis _ _ _ _ _ predict _ fnInputs fnOutputs): RunnerInput): RunnerOutput =
         # Command must be ("<mkdir>", "-m", "{string mode}", "{string path}", Nil)
         require "<mkdir>", "-m", smode, path, Nil = cmd
         else panic "mkdirImp violated command-line contract"
@@ -295,29 +300,34 @@ def mkdirRunner: Runner =
 
         # Actually trigger the effects required by the job
         require Some mode = int smode
-        else failWithError "write {path}: Unable to convert mode to Integer ({smode})"
+        else
+            Some "write {path}: Unable to convert mode to Integer ({smode})".makeError
+            | RunnerOutput Nil Nil Nil emptyUsage
 
         require True = mode >= 0 && mode <= 0x1ff
-        else failWithError "mkdir {path}: Invalid mode ({smode})"
+        else
+            Some "mkdir {path}: Invalid mode ({smode})".makeError
+            | RunnerOutput Nil Nil Nil emptyUsage
 
         def mkdirTask = primMkdir mode path
 
         # Wait for the virtual job to complete
-        require Pass reality = job.getJobReality
+        def Pair usage runnerError = match job.getJobReality
+            Fail err -> Pair emptyUsage (Some err)
+            Pass reality -> Pair reality None
+
+        def fileInputs =
+            vis
+            | map getPathName
+            | fnInputs
 
         match mkdirTask
-            Fail f -> failWithError f
+            Fail msg -> RunnerOutput fileInputs Nil Nil usage (Some msg.makeError)
             Pass path ->
-                def fileInputs =
-                    vis
-                    | map getPathName
-                    | fnInputs
-
                 def cleanable = (path, Nil)
                 def fileOutputs = fnOutputs cleanable
 
-                RunnerOutput fileInputs fileOutputs cleanable reality 0
-                | Pass
+                RunnerOutput fileInputs fileOutputs cleanable usage runnerError
 
     makeRunner "mkdir" run
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -436,7 +436,7 @@ export def unsafe_reportJobRunnerError (job: Job) (error: String): Job =
 # this out-of-band mechanism for both Wake related reporting as well as for runner scripts that are considered to
 # be an extension of the runner. A job's runner status is default set to be 0.
 def unsafe_primJobSetRunnerStatus (job: Job) (status: Option Error): Unit = match status
-    None -> Unit
+    None -> (\_ prim "job_clear_runner_status") job
     # Just pass in the String, since the database isn't going to store the stack trace anyway.
     Some err -> (\_ \_ prim "job_set_runner_status") job err.getErrorCause
 
@@ -449,7 +449,7 @@ export def unsafe_getJobRunnerStatus (job: Job): Result (Option String) Error =
     def raw job = prim "job_runner_status"
 
     raw job
-    | rmap (\status if status ==* "" then None else Some status)
+    | rmap getFail
 
 export def getJobInputs (job: Job): Result (List Path) Error =
     tree job 1

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -430,21 +430,29 @@ export def unsafe_reportJobRunnerOutput (job: Job) (output: String): Job =
 export def unsafe_reportJobRunnerError (job: Job) (error: String): Job =
     (\j \e prim "job_report_runner_error") job error
 
-# Set a runner status for a job
-# The runner status code is used to determine if the runner that a job ran on succeeded (0) or failed (> 0).
-# Since runner status is not inherrient to a jobs execution, runners should manually set the status through
-# this out-of-band mechanism for both Wake related reporting as well as for runner scripts that are considered to
-# be an extension of the runner. A job's runner status is default set to be 0.
+# Set a runner status message for a job.
+# This allows tracking of runner errors that are not directly related to the job's execution -- if
+# `None` the *runner* succeeded regardless of whether or not the Job did, while if `Some` then the
+# runner failed (whether before or after launching the job).  This should only be called by the
+# `runAlways` infrastructure, while any other (runner) code can simply pass the status message in the final
+# `RunnerOutput.RunnerError` field.
 def unsafe_primJobSetRunnerStatus (job: Job) (status: Option Error): Unit = match status
-    None -> (\_ prim "job_clear_runner_status") job
     # Just pass in the String, since the database isn't going to store the stack trace anyway.
     Some err -> (\_ \_ prim "job_set_runner_status") job err.getErrorCause
+    # This will typically be unnecessary since the default value for the database column is NULL
+    # (no runner error), and Wake should never cache a job with a runner error, but it's here just
+    # in case the same row gets reused and the runner status message in it needs to be cleared.
+    None -> (\_ prim "job_clear_runner_status") job
 
 # Get the runner status from a job.
-# The runner status code is used to determine if the runner that a job ran on succeeded (0) or failed (> 0).
+# The runner status is used to determine if the runner that a job ran on succeeded (`None`) or
+# failed (`Some`) and if the latter, why.
+#
 # Jobs that have a failed runner status are not cached.
 #
-# Marked unsafe as Runner status is not cached and cannot guarantee reproduciblity.
+# Marked unsafe as Runner status is not cached and cannot guarantee reproducibility.  In general,
+# this function should only be called by functions which construct and/or publish an execution
+# report, without the downstream logic depending on the contents of that report.
 export def unsafe_getJobRunnerStatus (job: Job): Result (Option String) Error =
     def raw job = prim "job_runner_status"
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -97,7 +97,7 @@ export def primJobLaunch (job: Job) (jobKey: JobKey) (usage: Usage): Unit =
 # Complete a job before launch with userland defined failure
 export def primJobFailLaunch (job: Job) (error: Error): Unit =
     def _ = (\_ \_ prim "job_fail_launch") job error
-    def _ = unsafe_reportJobRunnerFailure job (error.getErrorCause) 1
+    def _ = unsafe_reportJobRunnerError job (error.getErrorCause)
 
     Unit
 
@@ -107,10 +107,6 @@ export def markJobSetupFailure job err =
     def Unit = primJobFailLaunch job err
 
     Fail err
-
-# Complete a job after launch with userland defined failure
-export def primJobFailFinish (job: Job) (error: Error): Unit =
-    (\_ \_ prim "job_fail_finish") job error
 
 # Complete a job successfully by providing to the runtime the inputs/outputs/usage of the job
 export def primJobFinish (job: Job) (inputs: String) (outputs: String) (all_outputs: String) (usage: Usage): Unit =
@@ -173,15 +169,15 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
         def RunnerOutput inputs outputs cleanable reality runnerError =
             run job (RunnerInput label cmd vis env dir stdin res prefix usage isatty finputs foutputs)
 
-        def final _ = match runnerError
-            Some e -> primJobFailFinish job e
-            None ->
-                def hashedOutputs =
-                    outputs
-                    | computeHashes prefix
-                    | implode
+        def final _ =
+            def hashedOutputs =
+                outputs
+                | computeHashes prefix
+                | implode
 
-                primJobFinish job inputs.implode hashedOutputs cleanable.implode reality
+            def _ = unsafe_primJobSetRunnerStatus job runnerError
+
+            primJobFinish job inputs.implode hashedOutputs cleanable.implode reality
 
         # Make sure we don't hash files before the job has stopped running
         def _ = waitJobMerged final job
@@ -321,7 +317,7 @@ def guardPath job = match _
     _ ->
         # Check if it's a runner failure, if not then we know its a job failure
         def runnerFailure = match (unsafe_getJobRunnerStatus job)
-            Pass status if status != 0 -> "Runner failed with status {str status}"
+            Pass (Some msg) -> "Runner failed with error {msg}"
             _ -> "Non-zero exit status ({format job.getJobStatus})"
 
         failWithError "{runnerFailure} for job {str job.getJobId}: '{job.getJobDescription}'"
@@ -439,31 +435,21 @@ export def unsafe_reportJobRunnerError (job: Job) (error: String): Job =
 # Since runner status is not inherrient to a jobs execution, runners should manually set the status through
 # this out-of-band mechanism for both Wake related reporting as well as for runner scripts that are considered to
 # be an extension of the runner. A job's runner status is default set to be 0.
-#
-# Marked unsafe as this function should only be called for over-the-wall reporting for runners and because
-# of its uncacheablity as runner status is not cached.
-export def unsafe_primJobSetRunnerStatus (job: Job) (status: Integer): Unit =
-    (\_ \_ prim "job_set_runner_status") job status
+def unsafe_primJobSetRunnerStatus (job: Job) (status: Option Error): Unit = match status
+    None -> Unit
+    # Just pass in the String, since the database isn't going to store the stack trace anyway.
+    Some err -> (\_ \_ prim "job_set_runner_status") job err.getErrorCause
 
 # Get the runner status from a job.
 # The runner status code is used to determine if the runner that a job ran on succeeded (0) or failed (> 0).
 # Jobs that have a failed runner status are not cached.
 #
 # Marked unsafe as Runner status is not cached and cannot guarantee reproduciblity.
-export def unsafe_getJobRunnerStatus (job: Job): Result Integer Error =
-    (\j prim "job_runner_status") job
+export def unsafe_getJobRunnerStatus (job: Job): Result (Option String) Error =
+    def raw job = prim "job_runner_status"
 
-# Report a runner error and set runner status for a job.
-# This is a convenience function that calls both makeJobRunnerError and unsafe_primJobSetRunnerStatus. This function
-# is also utilized by primJobFailLaunch to report runner errors before a job is launched.
-#
-# Marked unsafe as this function should only be called for over-the-wall reporting for runners and because
-# of its uncacheablity as runner errors and runner status are not cached.
-export def unsafe_reportJobRunnerFailure (job: Job) (error: String) (status: Integer): Job =
-    def _ = unsafe_reportJobRunnerError job error
-    def _ = unsafe_primJobSetRunnerStatus job status
-
-    job
+    raw job
+    | rmap (\status if status ==* "" then None else Some status)
 
 export def getJobInputs (job: Job): Result (List Path) Error =
     tree job 1
@@ -506,7 +492,7 @@ export def isJobOk (job: Job): Boolean =
     if jobSuccess then
         match (unsafe_getJobRunnerStatus job)
             Fail _ -> False
-            Pass status -> status == 0
+            Pass status -> isNone status
     else
         False
 

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -170,12 +170,12 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
             getJobRecord job
             | getOrElse uusage
 
-        def output =
+        def RunnerOutput inputs outputs cleanable reality runnerError =
             run job (RunnerInput label cmd vis env dir stdin res prefix usage isatty finputs foutputs)
 
-        def final _ = match output
-            Fail e -> primJobFailFinish job e
-            Pass (RunnerOutput inputs outputs cleanable reality _) ->
+        def final _ = match runnerError
+            Some e -> primJobFailFinish job e
+            None ->
                 def hashedOutputs =
                     outputs
                     | computeHashes prefix

--- a/share/wake/lib/system/job.wake
+++ b/share/wake/lib/system/job.wake
@@ -171,7 +171,7 @@ def runAlways cmd env dir stdin res uusage finputs foutputs vis keep run echo st
             | getOrElse uusage
 
         def output =
-            run job (Pass (RunnerInput label cmd vis env dir stdin res prefix usage isatty finputs foutputs))
+            run job (RunnerInput label cmd vis env dir stdin res prefix usage isatty finputs foutputs)
 
         def final _ = match output
             Fail e -> primJobFailFinish job e

--- a/share/wake/lib/system/job_cache_runner.wake
+++ b/share/wake/lib/system/job_cache_runner.wake
@@ -139,7 +139,7 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
 
         # Now we need to run the job
         require Pass (RunnerOutput inputs outputs cleanable usage runnerStatus) =
-            baseDoIt job (Pass input)
+            baseDoIt job input
 
         def Usage status runtime cputime mem ibytes obytes = usage
         def inputsTree = listToTree scmpCanonical inputs

--- a/share/wake/lib/system/job_cache_runner.wake
+++ b/share/wake/lib/system/job_cache_runner.wake
@@ -53,13 +53,19 @@ def getPath input =
     jField elem "path"
     | jString
 
+def failureToOutput (result: Result a Error): Result a RunnerOutput =
+    require Fail err = result
+
+    RunnerOutput Nil Nil Nil emptyUsage (Some err)
+    | Fail
+
 # wakeroot is the absolute sandbox-path from which input and output files will
 # be interpreted as being relative to if they're in fact relative.
 export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakeroot: String) ((Runner name baseDoIt): Runner): Runner =
     def job_cache_read str = prim "job_cache_read"
     def job_cache_add str = prim "job_cache_add"
 
-    def run (job: Job) (input: RunnerInput): Result RunnerOutput Error =
+    def run (job: Job) (input: RunnerInput): Result RunnerOutput RunnerOutput =
         def (RunnerInput label cmd vis env dir stdin _ prefix _ _ _ _) = input
 
         def mkVisJson (Path path hash) =
@@ -73,6 +79,7 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
         require Pass hashKey =
             hashFn input
             | rmapFail (markJobSetupFailure job)
+            | failureToOutput
 
         def jobCacheJsonIn =
             prettyJSON
@@ -103,6 +110,7 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
         require Pass (jobCacheJsonOut; cacheHit) =
             jobCacheJsonOutResult
             | rmapFail (markJobSetupFailure job)
+            | failureToOutput
 
         def isDebugOn =
             require Some value = getenv "DEBUG_WAKE_SHARED_CACHE"
@@ -125,10 +133,11 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
             require Pass (JobCacheMatch inputs outputs stdout stderr predict) =
                 parseJobCacheMatch job jobCacheJsonOut
                 | rmapFail (markJobSetupFailure job)
+                | failureToOutput
 
             def _ = primJobVirtual job stdout stderr predict
 
-            Pass (RunnerOutput inputs outputs Nil predict 0)
+            Pass (RunnerOutput inputs outputs Nil predict None)
 
         def _ =
             require True = isDebugOn
@@ -138,9 +147,8 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
             True
 
         # Now we need to run the job
-        require Pass (RunnerOutput inputs outputs cleanable usage runnerStatus) =
-            baseDoIt job input
-
+        def baseOutput = baseDoIt job input
+        def RunnerOutput inputs outputs _ usage runnerError = baseOutput
         def Usage status runtime cputime mem ibytes obytes = usage
         def inputsTree = listToTree scmpCanonical inputs
 
@@ -157,8 +165,23 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
 
             JArray (map mkVisJson readPaths)
 
-        require Pass stdout = job.getJobFailedStdoutRaw
-        require Pass stderr = job.getJobFailedStderrRaw
+        def failedStreamOutput result =
+            require Fail err = result
+
+            require None = baseOutput.getRunnerOutputRunnerError
+            else Fail baseOutput
+
+            baseOutput
+            | setRunnerOutputRunnerError (Some err)
+            | Fail
+
+        require Pass stdout =
+            job.getJobFailedStdoutRaw
+            | failedStreamOutput
+
+        require Pass stderr =
+            job.getJobFailedStderrRaw
+            | failedStreamOutput
 
         def jobCacheAddJson =
             prettyJSON
@@ -199,7 +222,7 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
             require True = status == 0
             else Pass ""
 
-            require True = runnerStatus == 0
+            require None = runnerError
             else Pass ""
 
             # Sometimes we want a read-only cache. For instance read-only pre-merge
@@ -209,9 +232,15 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
 
             job_cache_add jobCacheAddJson
 
-        Pass (RunnerOutput (map getPathName vis) outputs cleanable usage runnerStatus)
+        baseOutput
+        | setRunnerOutputInputs (map getPathName vis)
+        | Pass
 
-    makeRunner "job-cache: {name}" run
+    def getEither = match _
+        Pass x -> x
+        Fail x -> x
+
+    makeRunner "job-cache: {name}" (run _ _ | getEither)
 
 tuple JobCacheMatch =
     Inputs: List String

--- a/share/wake/lib/system/job_cache_runner.wake
+++ b/share/wake/lib/system/job_cache_runner.wake
@@ -53,7 +53,7 @@ def getPath input =
     jField elem "path"
     | jString
 
-def failureToOutput (result: Result a Error): Result a RunnerOutput =
+def errorToOutput (result: Result a Error): Result a RunnerOutput =
     require Fail err = result
 
     RunnerOutput Nil Nil Nil emptyUsage (Some err)
@@ -65,6 +65,9 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
     def job_cache_read str = prim "job_cache_read"
     def job_cache_add str = prim "job_cache_add"
 
+    # For simplicity, still allow early-exit from this function by using a `Result` type; since both
+    # sides are the same and will be unified before it's passed to `makeRunner` below, the choice of
+    # `Pass` or `Fail` for any specific return value is arbitrary.
     def run (job: Job) (input: RunnerInput): Result RunnerOutput RunnerOutput =
         def (RunnerInput label cmd vis env dir stdin _ prefix _ _ _ _) = input
 
@@ -79,7 +82,7 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
         require Pass hashKey =
             hashFn input
             | rmapFail (markJobSetupFailure job)
-            | failureToOutput
+            | errorToOutput
 
         def jobCacheJsonIn =
             prettyJSON
@@ -110,7 +113,7 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
         require Pass (jobCacheJsonOut; cacheHit) =
             jobCacheJsonOutResult
             | rmapFail (markJobSetupFailure job)
-            | failureToOutput
+            | errorToOutput
 
         def isDebugOn =
             require Some value = getenv "DEBUG_WAKE_SHARED_CACHE"
@@ -133,7 +136,7 @@ export def mkJobCacheRunner (hashFn: RunnerInput => Result String Error) (wakero
             require Pass (JobCacheMatch inputs outputs stdout stderr predict) =
                 parseJobCacheMatch job jobCacheJsonOut
                 | rmapFail (markJobSetupFailure job)
-                | failureToOutput
+                | errorToOutput
 
             def _ = primJobVirtual job stdout stderr predict
 

--- a/share/wake/lib/system/remote_cache_api_test.wake
+++ b/share/wake/lib/system/remote_cache_api_test.wake
@@ -24,9 +24,9 @@ export def testDisablingCacheWithEndpoints (api: RemoteCacheApi): Result Unit Er
 
     def testJobAllowed Unit: Result Unit Error =
         def input =
-            RunnerInput "test" Nil Nil Nil "." "" Nil "" (Usage 0 0.0 0.0 0 0 0) False (\x x) (\x x)
+            RunnerInput "test" Nil Nil Nil "." "" Nil "" emptyUsage False (\x x) (\x x)
 
-        def output = RunnerOutput Nil Nil Nil (Usage 0 0.0 0.0 0 0 0) 0
+        def output = RunnerOutput Nil Nil Nil emptyUsage None
         def req = mkCacheAllowedRequest input output "test-hash"
 
         require Pass _ = rscApiCheckJobAllowed req api

--- a/share/wake/lib/system/remote_cache_api_test.wake
+++ b/share/wake/lib/system/remote_cache_api_test.wake
@@ -23,9 +23,7 @@ export def testDisablingCacheWithEndpoints (api: RemoteCacheApi): Result Unit Er
         Pass Unit
 
     def testJobAllowed Unit: Result Unit Error =
-        def input =
-            RunnerInput "test" Nil Nil Nil "." "" Nil "" emptyUsage False (\x x) (\x x)
-
+        def input = RunnerInput "test" Nil Nil Nil "." "" Nil "" emptyUsage False (\x x) (\x x)
         def output = RunnerOutput Nil Nil Nil emptyUsage None
         def req = mkCacheAllowedRequest input output "test-hash"
 

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -38,30 +38,30 @@ export target rscRunner (rscApi: RemoteCacheApi): Runner =
 export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => Result String Error) (wakeroot: String) ((Runner name baseDoIt): Runner): Runner =
     def runJobAndUpload job input hashKey =
         # Run the job to get the results
-        require Pass output = baseDoIt job input
+        def output = baseDoIt job input
 
         # Don't cache failing jobs
         require True = output.getRunnerOutputUsage.getUsageStatus == 0
-        else Pass output
+        else output
 
-        require True = output.getRunnerOutputRunnerStatus == 0
-        else Pass output
+        require None = output.getRunnerOutputRunnerError
+        else output
 
         # If pushing to the cache is not enabled don't bother
         require True = rscApi.getRemoteCacheApiCanPush
-        else Pass output
+        else output
 
         # If the server denies caching the job then skip
         require Pass True =
             (rscApi | rscApiCheckJobAllowed (mkCacheAllowedRequest input output hashKey))
-        else Pass output
+        else output
 
         # Post the job to the server. This is left as 'def _' so that wake won't block progess
         # on it but it will stil be joined on before wake exits. Regardless of the result this
         # call should return the passing output to allow the build to continue
         def _ = postJob rscApi job wakeroot hashKey input output
 
-        Pass output
+        output
 
     def rehydrateJob details label input job =
         def _ =
@@ -247,14 +247,17 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
         #     by the same job. If so, upload the target as a "hidden" output file. On rehydration
         #     retore the file as normal but don't list it in the outputs.
         ## -------------------------------------------------------------------------------------- ##
-        Pass (RunnerOutput inputs outputs cleanableOutputs predict 0)
+        Pass (RunnerOutput inputs outputs cleanableOutputs predict None)
 
-    def run (job: Job) (input: RunnerInput): Result RunnerOutput Error =
+    def run (job: Job) (input: RunnerInput): RunnerOutput =
         def label = input.getRunnerInputLabel
 
-        require Pass hashKey =
+        def hashKeyResult =
             hashFn input
             | rmapFail (markJobSetupFailure job)
+
+        require Pass hashKey = hashKeyResult
+        else RunnerOutput Nil Nil Nil emptyUsage hashKeyResult.getFail
 
         # If pulling from the cache is not enabled don't bother searching.
         require True = rscApi.getRemoteCacheApiCanPull
@@ -293,7 +296,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
                 runJobAndUpload job input hashKey
             Match details -> match (rehydrateJob details label input job)
                 # If the rehydration succeeds return the job directly
-                Pass x -> Pass x
+                Pass x -> x
                 # Otherwise if hydration fails for any reason just run the job as normal.
                 # There is no point in attempting to push since the server just said its cached
                 Fail _ -> baseDoIt job input

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -38,7 +38,7 @@ export target rscRunner (rscApi: RemoteCacheApi): Runner =
 export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => Result String Error) (wakeroot: String) ((Runner name baseDoIt): Runner): Runner =
     def runJobAndUpload job input hashKey =
         # Run the job to get the results
-        require Pass output = baseDoIt job (Pass input)
+        require Pass output = baseDoIt job input
 
         # Don't cache failing jobs
         require True = output.getRunnerOutputUsage.getUsageStatus == 0
@@ -276,7 +276,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
 
             # This job isn't getting cached. That's probably preferable since the server
             # request failed but good to keep in mind.
-            baseDoIt job (Pass input)
+            baseDoIt job input
 
         # If a valid response is received from the server then handle it
         def cacheLookupSucceeded response = match response
@@ -296,7 +296,7 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
                 Pass x -> Pass x
                 # Otherwise if hydration fails for any reason just run the job as normal.
                 # There is no point in attempting to push since the server just said its cached
-                Fail _ -> baseDoIt job (Pass input)
+                Fail _ -> baseDoIt job input
 
         # Search the remote cache for the job
         match (rscApi | rscApiFindMatchingJob (mkSearchRequest input hashKey))

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -90,6 +90,11 @@ export tuple RunnerOutput =
     export CleanableOutputs: List String
     # The actual resource usage of the job that will be written to the database
     export Usage: Usage
+    # If the runner failed before or after launching the job, this will contain the error message
+    # as a status *separate* from the job's exit status.  Since it's all happening inside Wake,
+    # this can carry a more descriptive message than the standard numeric exit code -- however,
+    # the contents of that message should very rarely be incorporated into control-flow logic as
+    # it could very easily be unreproducible.
     export RunnerError: Option Error
 
 # A Runner describes a way to invoke a Plan to get a Job
@@ -128,7 +133,7 @@ export def localRunner: Runner =
         # Wait for the job to complete before calling fnOutputs
         def Pair usage runnerError = match job.getJobReality
             Fail err -> Pair emptyUsage (Some err)
-            # Set the runner status to be a success (`None`) - its the callers responsibility
+            # Set the runner status to be a success (`None`) - it's the callers responsibility
             # to set the appropriate status if the job that ran is an extension of a runner
             Pass reality -> Pair reality None
 
@@ -155,7 +160,7 @@ export def virtualRunner: Runner =
         # Wait for the job to complete before calling fnOutputs
         def Pair usage runnerError = match job.getJobReality
             Fail err -> Pair emptyUsage (Some err)
-            # Set the runner status to be a success (`None`) - its the callers responsibility
+            # Set the runner status to be a success (`None`) - it's the callers responsibility
             # to set the appropriate status if the job that ran is an extension of a runner
             Pass reality -> Pair reality None
 

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -94,7 +94,7 @@ export tuple RunnerOutput =
 # A Runner describes a way to invoke a Plan to get a Job
 export tuple Runner =
     export Name: String
-    Fn: Job => Result RunnerInput Error => Result RunnerOutput Error
+    Fn: Job => RunnerInput => Result RunnerOutput Error
 
 # makeRunner: Hides some of the boiler plate required to create a runner
 #
@@ -108,14 +108,7 @@ export tuple Runner =
 #
 # localRunner is a good reference implementation of the run function.
 export def makeRunner (name: String) (run: Job => RunnerInput => Result RunnerOutput Error): Runner =
-    def do job maybeInput = match maybeInput
-        Fail e ->
-            def _ = primJobFailLaunch job e
-
-            Fail e
-        Pass input -> run job input
-
-    Runner name do
+    Runner name run
 
 # localRunner: A runner that provides no sandboxing protections and no file tracking.
 #
@@ -303,7 +296,7 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
         # Dispatch to the local runner via composition and get the outputs
         def (Runner _ localRun) = localRunner
 
-        require Pass localOutput = localRun job (Pass localInput)
+        require Pass localOutput = localRun job localInput
 
         def statusCode = localOutput.getRunnerOutputUsage.getUsageStatus
         def runnerStatus = localOutput.getRunnerOutputRunnerStatus

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -26,7 +26,8 @@ export tuple Usage =
     export InBytes: Integer
     export OutBytes: Integer
 
-export def emptyUsage = Usage 0 0.0 0.0 0 0 0
+export def emptyUsage =
+    Usage 0 0.0 0.0 0 0 0
 
 export def getUsageThreads (Usage _ run cpu _ _ _: Usage): Double =
     if run ==. 0.0 then

--- a/share/wake/lib/system/runner.wake
+++ b/share/wake/lib/system/runner.wake
@@ -26,6 +26,8 @@ export tuple Usage =
     export InBytes: Integer
     export OutBytes: Integer
 
+export def emptyUsage = Usage 0 0.0 0.0 0 0 0
+
 export def getUsageThreads (Usage _ run cpu _ _ _: Usage): Double =
     if run ==. 0.0 then
         cpu
@@ -88,13 +90,12 @@ export tuple RunnerOutput =
     export CleanableOutputs: List String
     # The actual resource usage of the job that will be written to the database
     export Usage: Usage
-    # The runner status code (0 for success, non-zero for failure)
-    export RunnerStatus: Integer
+    export RunnerError: Option Error
 
 # A Runner describes a way to invoke a Plan to get a Job
 export tuple Runner =
     export Name: String
-    Fn: Job => RunnerInput => Result RunnerOutput Error
+    Fn: Job => RunnerInput => RunnerOutput
 
 # makeRunner: Hides some of the boiler plate required to create a runner
 #
@@ -107,7 +108,7 @@ export tuple Runner =
 # instead of accepting an arbitrary runner parameter.
 #
 # localRunner is a good reference implementation of the run function.
-export def makeRunner (name: String) (run: Job => RunnerInput => Result RunnerOutput Error): Runner =
+export def makeRunner (name: String) (run: Job => RunnerInput => RunnerOutput): Runner =
     Runner name run
 
 # localRunner: A runner that provides no sandboxing protections and no file tracking.
@@ -115,7 +116,7 @@ export def makeRunner (name: String) (run: Job => RunnerInput => Result RunnerOu
 # You must use Fn{Inputs,Outputs} to fill in this information for wake to maintain safety and reusability
 # Advanced usage only, proceed with caution
 export def localRunner: Runner =
-    def run (job: Job) ((RunnerInput _ cmd vis env dir stdin _ _ predict isAtty fnInputs fnOutputs): RunnerInput): Result RunnerOutput Error =
+    def run (job: Job) ((RunnerInput _ cmd vis env dir stdin _ _ predict isAtty fnInputs fnOutputs): RunnerInput): RunnerOutput =
         def jobKey = JobKey dir stdin env.implode cmd.implode 0 "" isAtty.booleanToInteger
         def _ = primJobLaunch job jobKey predict
 
@@ -125,18 +126,17 @@ export def localRunner: Runner =
             | fnInputs
 
         # Wait for the job to complete before calling fnOutputs
-        require Pass reality = job.getJobReality
-
-        # Set the runner status to be a success - its the callers responsibility
-        # to set the appropriate status if the job that ran is an extension of a runner
-        def runnerStatus = 0
+        def Pair usage runnerError = match job.getJobReality
+            Fail err -> Pair emptyUsage (Some err)
+            # Set the runner status to be a success (`None`) - its the callers responsibility
+            # to set the appropriate status if the job that ran is an extension of a runner
+            Pass reality -> Pair reality None
 
         # Caller needs to fill this in from nothing
         def cleanable = Nil
         def fileOutputs = fnOutputs cleanable
 
-        RunnerOutput fileInputs fileOutputs cleanable reality runnerStatus
-        | Pass
+        RunnerOutput fileInputs fileOutputs cleanable usage runnerError
 
     makeRunner "local" run
 
@@ -144,7 +144,7 @@ export def localRunner: Runner =
 #
 # This runner is useful for tracking a unit of work that is job like but not launched as a process
 export def virtualRunner: Runner =
-    def run (job: Job) ((RunnerInput _ _ vis _ _ _ _ _ predict _ fnInputs fnOutputs): RunnerInput): Result RunnerOutput Error =
+    def run (job: Job) ((RunnerInput _ _ vis _ _ _ _ _ predict _ fnInputs fnOutputs): RunnerInput): RunnerOutput =
         def _ = primJobVirtual job "" "" predict
 
         def fileInputs =
@@ -153,17 +153,17 @@ export def virtualRunner: Runner =
             | fnInputs
 
         # Wait for the job to complete before calling fnOutputs
-        require Pass reality = job.getJobReality
-
-        def runnerStatus = 0
-        def _ = unsafe_primJobSetRunnerStatus job runnerStatus
+        def Pair usage runnerError = match job.getJobReality
+            Fail err -> Pair emptyUsage (Some err)
+            # Set the runner status to be a success (`None`) - its the callers responsibility
+            # to set the appropriate status if the job that ran is an extension of a runner
+            Pass reality -> Pair reality None
 
         # Caller needs to fill this in from nothing
         def cleanable = Nil
         def fileOutputs = fnOutputs cleanable
 
-        RunnerOutput fileInputs fileOutputs cleanable reality runnerStatus
-        | Pass
+        RunnerOutput fileInputs fileOutputs cleanable usage runnerError
 
     makeRunner "virtual" run
 
@@ -234,9 +234,13 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
     def script = which (simplify rawScript)
     def executeOk = access script xOK
 
-    def run (job: Job) ((RunnerInput label command visible environment directory stdin res prefix record isatty fnInputs fnOutputs): RunnerInput): Result RunnerOutput Error =
+    def run (job: Job) ((RunnerInput label command visible environment directory stdin res prefix record isatty fnInputs fnOutputs): RunnerInput): RunnerOutput =
         require True = executeOk
-        else markJobSetupFailure job "Runner {script} is not executable".makeError
+        else
+            def runnerError = "Runner {script} is not executable".makeError
+            def _ = markJobSetupFailure job runnerError
+
+            RunnerOutput Nil Nil Nil emptyUsage (Some runnerError)
 
         def Usage status runtime cputime membytes inbytes outbytes = record
 
@@ -269,10 +273,13 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
         def specFile = "{buildDirName}/spec-{prefix}.json"
         def resultFile = "{buildDirName}/result-{prefix}.json"
 
-        require Pass _ =
+        def writeResult =
             write specFile (prettyJSON json)
             | addErrorContext "Failed to 'write {specFile}: '"
             | rmapFail (markJobSetupFailure job)
+
+        require Pass _ = writeResult
+        else RunnerOutput Nil Nil Nil emptyUsage writeResult.getFail
 
         def cmd = script, "-I", "-p", specFile, "-o", resultFile, extraArgs
 
@@ -295,18 +302,20 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
 
         # Dispatch to the local runner via composition and get the outputs
         def (Runner _ localRun) = localRunner
-
-        require Pass localOutput = localRun job localInput
-
+        def localOutput = localRun job localInput
         def statusCode = localOutput.getRunnerOutputUsage.getUsageStatus
-        def runnerStatus = localOutput.getRunnerOutputRunnerStatus
 
+        # The `localRunner` output reflects the status of the runner itself, not the job, and so we
+        # need to save that separately and extract the job status from the result file.
         require 0 = statusCode
-        else failWithError "Non-zero exit status ({str statusCode}) for JSON runner {script} on {specFile}"
+        else
+            Some "Non-zero exit status ({str statusCode}) for JSON runner on {specFile}".makeError
+            | RunnerOutput Nil Nil (specFile, Nil) emptyUsage
 
         require Pass content = parseJSONFile (Path resultFile "BadHash")
-
-        def _ = markFileCleanable resultFile
+        else
+            Some "Failed to parse output {resultFile} for JSON runner".makeError
+            | RunnerOutput Nil Nil (specFile, Nil) emptyUsage
 
         def field name = match _ _
             _ (Fail f) -> Fail f
@@ -334,10 +343,12 @@ export def makeJSONRunner ((JSONRunnerPlan rawScript extraArgs extraEnv estimate
         def jsonOutputs = getK `outputs`
         def filteredInputs = fnInputs jsonInputs
         def filteredOutputs = fnOutputs jsonOutputs
+        def cleanableOutputs = specFile, resultFile, jsonOutputs
 
         match usageResult
-            Fail f -> Fail (makeError f)
-            Pass usage ->
-                Pass (RunnerOutput filteredInputs filteredOutputs jsonOutputs usage runnerStatus)
+            Pass usage -> RunnerOutput filteredInputs filteredOutputs cleanableOutputs usage None
+            Fail msg ->
+                Some msg.makeError
+                | RunnerOutput filteredInputs filteredOutputs cleanableOutputs emptyUsage
 
     makeRunner "json-{script}" run

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1605,14 +1605,15 @@ void Database::set_runner_status(long job_id) {
   // Explicitly bind NULL (successful runner case)
   int ret = sqlite3_bind_null(imp->set_runner_status, 1);
   if (ret != SQLITE_OK) {
-    std::cerr << why << "; sqlite3_bind_null(1): " << sqlite3_errmsg(sqlite3_db_handle(imp->set_runner_status)) << std::endl;
+    std::cerr << why << "; sqlite3_bind_null(1): "
+              << sqlite3_errmsg(sqlite3_db_handle(imp->set_runner_status)) << std::endl;
     exit(1);
   }
   bind_integer(why, imp->set_runner_status, 2, job_id);
   single_step(why, imp->set_runner_status, imp->debugdb);
 }
 
-void Database::set_runner_status(long job_id, const std::string& status_message) {
+void Database::set_runner_status(long job_id, const std::string &status_message) {
   const char *why = "Could not set runner status";
   bind_string(why, imp->set_runner_status, 1, status_message);
   bind_integer(why, imp->set_runner_status, 2, job_id);

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -1340,7 +1340,7 @@ static JobReflection find_one(const Database *db, sqlite3_stmt *query) {
     // NULL in database - return false to indicate success (no error)
     desc.runner_status = {false, ""};
   } else {
-    // Non-NULL value (including empty string) - return true with the actual string
+    // Non-NULL value (including empty string) - return true with the actual status message
     desc.runner_status = {true, rip_column(query, 18)};
   }
 
@@ -1612,9 +1612,9 @@ void Database::set_runner_status(long job_id) {
   single_step(why, imp->set_runner_status, imp->debugdb);
 }
 
-void Database::set_runner_status(long job_id, const std::string& status) {
+void Database::set_runner_status(long job_id, const std::string& status_message) {
   const char *why = "Could not set runner status";
-  bind_string(why, imp->set_runner_status, 1, status);
+  bind_string(why, imp->set_runner_status, 1, status_message);
   bind_integer(why, imp->set_runner_status, 2, job_id);
   single_step(why, imp->set_runner_status, imp->debugdb);
 }
@@ -1628,7 +1628,7 @@ std::pair<bool, std::string> Database::get_runner_status(long job_id) {
       // NULL in database - return false to indicate success (no error)
       status = {false, ""};
     } else {
-      // Non-NULL value (including empty string) - return true with the actual string
+      // Non-NULL value (including empty string) - return true with the actual status message
       status = {true, rip_column(imp->get_runner_status, 0)};
     }
   }

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -188,9 +188,10 @@ struct Database {
   std::vector<std::pair<std::string, int>> get_interleaved_output(long job_id) const;
 
   void set_runner_status(long job_id);  // Sets to NULL (successful runner case)
-  void set_runner_status(long job_id, const std::string& status_message);
+  void set_runner_status(long job_id, const std::string &status_message);
 
-  std::pair<bool, std::string> get_runner_status(long job_id);  // bool=true if error present, false if NULL
+  // bool=true if error present, false if NULL
+  std::pair<bool, std::string> get_runner_status(long job_id);
 };
 
 #endif

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "json/json5.h"
@@ -186,9 +187,10 @@ struct Database {
 
   std::vector<std::pair<std::string, int>> get_interleaved_output(long job_id) const;
 
+  void set_runner_status(long job_id);  // Sets to NULL (successful runner case)
   void set_runner_status(long job_id, const std::string& status);
 
-  std::string get_runner_status(long job_id);
+  std::pair<bool, std::string> get_runner_status(long job_id);  // bool=true if error present, false if NULL
 };
 
 #endif

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -90,7 +90,7 @@ struct JobReflection {
   std::vector<FileReflection> inputs;
   std::vector<FileReflection> outputs;
   std::vector<JobTag> tags;
-  std::string runner_status;
+  std::pair<bool, std::string> runner_status;  // bool=true if error present, false if NULL
 
   JAST to_json() const;
   JAST to_structured_json() const;

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -89,7 +89,7 @@ struct JobReflection {
   std::vector<FileReflection> inputs;
   std::vector<FileReflection> outputs;
   std::vector<JobTag> tags;
-  int runner_status;
+  std::string runner_status;
 
   JAST to_json() const;
   JAST to_structured_json() const;
@@ -186,9 +186,9 @@ struct Database {
 
   std::vector<std::pair<std::string, int>> get_interleaved_output(long job_id) const;
 
-  void set_runner_status(long job_id, int status);
+  void set_runner_status(long job_id, const std::string& status);
 
-  int get_runner_status(long job_id);
+  std::string get_runner_status(long job_id);
 };
 
 #endif

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -188,7 +188,7 @@ struct Database {
   std::vector<std::pair<std::string, int>> get_interleaved_output(long job_id) const;
 
   void set_runner_status(long job_id);  // Sets to NULL (successful runner case)
-  void set_runner_status(long job_id, const std::string& status);
+  void set_runner_status(long job_id, const std::string& status_message);
 
   std::pair<bool, std::string> get_runner_status(long job_id);  // bool=true if error present, false if NULL
 };

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1598,7 +1598,7 @@ static PRIMFN(prim_job_report_runner_error) {
   STRING(error_message, 1);
 
   job->db->save_output(job->job, 4, error_message->c_str(), error_message->size(), 0);
-  job->state |= STATE_RUNNER_ERR;
+  // Don't set STATE_RUNNER_ERR here - that should only be set when the stream is closed
 
   runtime.heap.reserve(WJob::reserve());
   runtime.schedule(WJob::claim(runtime.heap, job));
@@ -1617,7 +1617,7 @@ static PRIMFN(prim_job_report_runner_output) {
   STRING(output_message, 1);
 
   job->db->save_output(job->job, 3, output_message->c_str(), output_message->size(), 0);
-  job->state |= STATE_RUNNER_OUT;
+  // Don't set STATE_RUNNER_OUT here - that should only be set when the stream is closed
 
   runtime.heap.reserve(WJob::reserve());
   runtime.schedule(WJob::claim(runtime.heap, job));

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1720,8 +1720,9 @@ static PRIMFN(prim_job_finish) {
                       int64_ns(job->start), int64_ns(job->stop), job->code.data[0], keep,
                       job->report);
 
-  // Runner status is left untouched to avoid overwriting any errors set by `prim_job_set_runner_status`
-  // if that was called first, with the safe fallback of a NULL database value on runner success.
+  // Runner status is left untouched to avoid overwriting any errors set by
+  // `prim_job_set_runner_status` if that was called first, with the safe fallback of a NULL
+  // database value on runner success.
 
   job->state |= STATE_FINISHED;
 
@@ -1952,7 +1953,7 @@ static PRIMFN(prim_job_runner_status) {
 
   // Wrap in outer Result for lookup-prim success -> Pass (Result Unit String)
   runtime.heap.reserve(reserve_result());
-  RETURN(claim_result(runtime.heap, true, static_cast<Value*>(inner_result)));
+  RETURN(claim_result(runtime.heap, true, static_cast<Value *>(inner_result)));
 }
 
 static PRIMTYPE(type_access) {

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -1894,9 +1894,9 @@ static PRIMTYPE(type_job_set_runner_status) {
 static PRIMFN(prim_job_set_runner_status) {
   EXPECT(2);
   JOB(job, 0);
-  STRING(error_message, 1);
+  STRING(status_message, 1);
 
-  job->db->set_runner_status(job->job, error_message->as_str());
+  job->db->set_runner_status(job->job, status_message->as_str());
 
   runtime.heap.reserve(reserve_unit());
   RETURN(claim_unit(runtime.heap));
@@ -1936,14 +1936,14 @@ static PRIMFN(prim_job_runner_status) {
 
   std::pair<bool, std::string> status_result = job->db->get_runner_status(job->job);
   bool has_error = status_result.first;
-  std::string error_message = status_result.second;
+  std::string status_message = status_result.second;
 
   // Create the inner `Result Unit String` (isomorphic to `Option String`)
   HeapObject *inner_result;
   if (has_error) {
     // Failure case: runner error message present (including empty string) -> Fail String
-    runtime.heap.reserve(reserve_result() + String::reserve(error_message.size()));
-    inner_result = claim_result(runtime.heap, false, String::claim(runtime.heap, error_message));
+    runtime.heap.reserve(reserve_result() + String::reserve(status_message.size()));
+    inner_result = claim_result(runtime.heap, false, String::claim(runtime.heap, status_message));
   } else {
     // Success case: no runner error (NULL in database) -> Pass Unit
     runtime.heap.reserve(reserve_result() + reserve_unit());

--- a/src/runtime/schema.h
+++ b/src/runtime/schema.h
@@ -1,7 +1,7 @@
 #ifndef WAKE_SCHEMA_H
 #define WAKE_SCHEMA_H
 
-#define SCHEMA_VERSION "8"
+#define SCHEMA_VERSION "9"
 
 // Increment the SCHEMA_VERSION every time the below string changes.
 // Also add migrations to the wake-migration tool if needed.
@@ -55,12 +55,11 @@ inline const char* getWakeSchemaSQL() {
          "  keep        integer not null default 0,"
          "  stale       integer not null default 0,"     // 0=false, 1=true
          "  is_atty     integer not null default 0,"     // 0=false, 1=true
-         "  runner_status integer not null default 0);"  // 0=success, non-zero=failure
+         "  runner_status text);"  // NULL=success, non-null string=failure message
          "create index if not exists job on jobs(directory, commandline, environment, stdin, "
          "signature, keep, job_id, stat_id);"
          "create index if not exists runner_status_idx on jobs(runner_status) WHERE runner_status "
-         "<> "
-         "0;"
+         "IS NOT NULL;"
          "create index if not exists jobstats on jobs(stat_id);"
          "create table if not exists filetree("
          "  tree_id  integer primary key autoincrement,"

--- a/src/runtime/schema.h
+++ b/src/runtime/schema.h
@@ -53,8 +53,8 @@ inline const char* getWakeSchemaSQL() {
          "  starttime   integer not null default 0,"
          "  endtime     integer not null default 0,"
          "  keep        integer not null default 0,"
-         "  stale       integer not null default 0,"     // 0=false, 1=true
-         "  is_atty     integer not null default 0,"     // 0=false, 1=true
+         "  stale       integer not null default 0,"  // 0=false, 1=true
+         "  is_atty     integer not null default 0,"  // 0=false, 1=true
          "  runner_status text);"  // NULL=success, non-null string=failure message
          "create index if not exists job on jobs(directory, commandline, environment, stdin, "
          "signature, keep, job_id, stat_id);"

--- a/tests/standard-library/runner-outputs/pass.sh
+++ b/tests/standard-library/runner-outputs/pass.sh
@@ -5,9 +5,8 @@ WAKE="${1:+$1/wake}"
 
 rm -f wake.db wake.log
 
-"${WAKE:-wake}" --stdout=warning,report testRunnerFailSuccess
+"${WAKE:-wake}" --stdout=warning,report testRunnerFailWithEmptyError
 "${WAKE:-wake}" --stdout=warning,report testRunnerFailWithJobFailure
-"${WAKE:-wake}" --stdout=warning,report testRunnerOutputStatus
 "${WAKE:-wake}" --stdout=warning,report testRunnerFailFinish
 "${WAKE:-wake}" --stdout=warning,report testRunnerOkSuccess
 "${WAKE:-wake}" --stdout=warning,report testWrapperRunnerStatus

--- a/tests/standard-library/runner-outputs/test.wake
+++ b/tests/standard-library/runner-outputs/test.wake
@@ -4,13 +4,13 @@
 export def testRunnerFailSuccess _: Result Unit Error =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job input
+        def result = virtRun job input
 
         # Report a runner error after the job completes
         def _ = unsafe_reportJobRunnerError job "Intentional runner error for testing"
         def _ = unsafe_primJobSetRunnerStatus job 1
 
-        Pass result
+        result
 
     def testRunner = makeRunner "test-runner-fail-success" run
 
@@ -36,7 +36,7 @@ export def testRunnerFailSuccess _: Result Unit Error =
     addErrorContext "runner-fail-success" check
 
 # Test that a runner preserves job failure status when both job and runner fail
-export def testRunnerFailWithJobFailure _ =
+export def testRunnerFailWithJobFailure _: Result Unit Error =
     def run job input =
         # Run a command that will fail with exit code 42
         def failingInput =
@@ -44,12 +44,12 @@ export def testRunnerFailWithJobFailure _ =
             | editRunnerInputCommand (\_ ("sh", "-c", "exit 42", Nil))
 
         def (Runner _ baseRun) = localRunner
-        require Pass result = baseRun job failingInput
+        def result = baseRun job failingInput
 
         # Report a runner error after the job completes
         def _ = unsafe_reportJobRunnerError job "Intentional runner error with job failure"
 
-        Pass result
+        result
 
     def testRunner = makeRunner "test-runner-fail-with-job-failure" run
 
@@ -78,17 +78,17 @@ export def testRunnerFailWithJobFailure _ =
     addErrorContext "runner-fail-with-job-failure" check
 
 # Test that RunnerOutput correctly includes and propagates runner status
-export def testRunnerOutputStatus _ =
+export def testRunnerOutputStatus _: Result Unit Error =
     # Create a custom runner that sets a specific runner status
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job input
+        def result = virtRun job input
 
         # Set a specific runner status
         def customStatus = 123
         def _ = unsafe_primJobSetRunnerStatus job customStatus
 
-        Pass result
+        result
 
     def testRunner = makeRunner "test-runner-output-status" run
 
@@ -107,13 +107,14 @@ export def testRunnerOutputStatus _ =
     addErrorContext "runner-output-status" check
 
 # Test that a runner can finish a job but mark it as failed
-export def testRunnerFailFinish _ =
+export def testRunnerFailFinish _: Result Unit Error =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass _ = virtRun job input
+        def result = virtRun job input
 
         # Force a failure outside of the actual job
-        failWithError "Mark job as failure"
+        result
+        | setRunnerOutputRunnerError (Some "Mark job as failure".makeError)
 
     def testRunner = makeRunner "test-runner-fail-finish" run
 
@@ -131,7 +132,7 @@ export def testRunnerFailFinish _ =
     addErrorContext "runner-fail-finish" check
 
 # Test that isJobOk returns true when there's no runner error
-export def testRunnerOkSuccess _ =
+export def testRunnerOkSuccess _: Result Unit Error =
     def job =
         makeExecPlan ("echo", "success", Nil) Nil
         | runJobWith localRunner
@@ -155,7 +156,7 @@ export def testWrapperRunnerStatus _: Result Unit Error =
     # Create an inner runner that sets a runner error and status
     def innerRun job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job input
+        def result = virtRun job input
 
         # Set a runner error
         def _ = unsafe_reportJobRunnerError job "Inner runner error\n"
@@ -164,7 +165,7 @@ export def testWrapperRunnerStatus _: Result Unit Error =
         def customStatus = 42
         def _ = unsafe_primJobSetRunnerStatus job customStatus
 
-        Pass result
+        result
 
     def innerRunner = makeRunner "inner-runner" innerRun
 
@@ -173,7 +174,7 @@ export def testWrapperRunnerStatus _: Result Unit Error =
         # First run the job with the inner runner
         def innerInput = input
         def (Runner _ innerDoIt) = innerRunner
-        require Pass result = innerDoIt job innerInput
+        def result = innerDoIt job innerInput
 
         match (unsafe_getJobRunnerError job)
             Pass errorMsg if errorMsg !=* "" ->
@@ -182,9 +183,9 @@ export def testWrapperRunnerStatus _: Result Unit Error =
                 def _ = unsafe_reportJobRunnerError job newErrorMsg
 
                 # Keep the same runner status (should be 42 from inner runner)
-                Pass result
+                result
             _ ->
-                Pass result
+                result
 
     def wrapperRunner = makeRunner "wrapper-runner" wrapperRun
 
@@ -273,11 +274,11 @@ export def testRunnerCustomOutput _: Result Unit Error =
     # Create a custom runner that reports output information
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job input
+        def result = virtRun job input
 
         def _ = unsafe_reportJobRunnerOutput job "Custom runner information: test data"
 
-        Pass result
+        result
 
     def testRunner = makeRunner "test-runner-custom-output" run
 

--- a/tests/standard-library/runner-outputs/test.wake
+++ b/tests/standard-library/runner-outputs/test.wake
@@ -4,7 +4,7 @@
 export def testRunnerFailSuccess _: Result Unit Error =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job (Pass input)
+        require Pass result = virtRun job input
 
         # Report a runner error after the job completes
         def _ = unsafe_reportJobRunnerError job "Intentional runner error for testing"
@@ -44,7 +44,7 @@ export def testRunnerFailWithJobFailure _ =
             | editRunnerInputCommand (\_ ("sh", "-c", "exit 42", Nil))
 
         def (Runner _ baseRun) = localRunner
-        require Pass result = baseRun job (Pass failingInput)
+        require Pass result = baseRun job failingInput
 
         # Report a runner error after the job completes
         def _ = unsafe_reportJobRunnerError job "Intentional runner error with job failure"
@@ -82,7 +82,7 @@ export def testRunnerOutputStatus _ =
     # Create a custom runner that sets a specific runner status
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job (Pass input)
+        require Pass result = virtRun job input
 
         # Set a specific runner status
         def customStatus = 123
@@ -110,7 +110,7 @@ export def testRunnerOutputStatus _ =
 export def testRunnerFailFinish _ =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass _ = virtRun job (Pass input)
+        require Pass _ = virtRun job input
 
         # Force a failure outside of the actual job
         failWithError "Mark job as failure"
@@ -155,7 +155,7 @@ export def testWrapperRunnerStatus _: Result Unit Error =
     # Create an inner runner that sets a runner error and status
     def innerRun job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job (Pass input)
+        require Pass result = virtRun job input
 
         # Set a runner error
         def _ = unsafe_reportJobRunnerError job "Inner runner error\n"
@@ -173,7 +173,7 @@ export def testWrapperRunnerStatus _: Result Unit Error =
         # First run the job with the inner runner
         def innerInput = input
         def (Runner _ innerDoIt) = innerRunner
-        require Pass result = innerDoIt job (Pass innerInput)
+        require Pass result = innerDoIt job innerInput
 
         match (unsafe_getJobRunnerError job)
             Pass errorMsg if errorMsg !=* "" ->
@@ -273,7 +273,7 @@ export def testRunnerCustomOutput _: Result Unit Error =
     # Create a custom runner that reports output information
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass result = virtRun job (Pass input)
+        require Pass result = virtRun job input
 
         def _ = unsafe_reportJobRunnerOutput job "Custom runner information: test data"
 

--- a/tests/standard-library/runner-outputs/test.wake
+++ b/tests/standard-library/runner-outputs/test.wake
@@ -1,35 +1,33 @@
 # Test cases for runner functionality including runner output, runner errors, and runner status
 
-# Test that a runner can fail a job even if the command succeeds
+# Test that a runner failure depends only on the Some/None of the error, not a non-empty error message
 export def testRunnerFailWithEmptyError _: Result Unit Error =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
         def result = virtRun job input
 
+        #def _ = unsafe_reportJobRunnerOutput job "Intentional runner error for testing"
+
         # Report a runner error after the job completes
         result
-        #| setRunnerOutputRunnerError (Some "".makeError)
+        | setRunnerOutputRunnerError (Some "".makeError)
 
-    def testRunner = makeRunner "test-runner-fail-success" run
+    def testRunner = makeRunner "test-runner-fail-empty-error" run
 
     def job =
-        makeExecPlan ("<test>", "runner-fail-success", Nil) Nil
+        makeExecPlan ("<test>", "runner-fail-empty-error", Nil) Nil
         | runJobWith testRunner
 
     def check =
-        #require False = job.isJobOk
-        #else failWithError "Expected isJobOk to return False for job with runner error"
-        require True = job.isJobOk
-        else failWithError "Expected isJobOk to return True for successful job"
+        require False = job.isJobOk
+        else failWithError "Expected isJobOk to return False for job with runner error"
         require Exited 0 = job.getJobStatus
         else failWithError "Expected job status to be 0, got {format job.getJobStatus}"
 
         # Runner status should be Some even though the error message is empty
         require Pass runnerStatus = job.unsafe_getJobRunnerStatus
-        #require Some "" = runnerStatus
-        #else failWithError "Expected empty but present runner status message, got: '{format runnerStatus}'"
-        require None = runnerStatus
-        else failWithError "Expected None runner status for successful job, got '{format runnerStatus}'"
+        require Some "" = runnerStatus
+        else failWithError "Expected empty but present runner status message, got: {format runnerStatus}"
 
         require Pass errorMsg = job.unsafe_getJobRunnerError
         #require True = errorMsg ==* "Intentional runner error for testing"
@@ -39,7 +37,7 @@ export def testRunnerFailWithEmptyError _: Result Unit Error =
 
         Pass Unit
 
-    addErrorContext "runner-fail-success" check
+    addErrorContext "runner-fail-empty-error" check
 
 # Test that a runner preserves job failure status when both job and runner fail
 export def testRunnerFailWithJobFailure _: Result Unit Error =

--- a/tests/standard-library/runner-outputs/test.wake
+++ b/tests/standard-library/runner-outputs/test.wake
@@ -6,7 +6,7 @@ export def testRunnerFailWithEmptyError _: Result Unit Error =
         def (Runner _ virtRun) = virtualRunner
         def result = virtRun job input
 
-        #def _ = unsafe_reportJobRunnerOutput job "Intentional runner error for testing"
+        def _ = unsafe_reportJobRunnerError job "Intentional runner error for testing"
 
         # Report a runner error after the job completes
         result
@@ -30,10 +30,8 @@ export def testRunnerFailWithEmptyError _: Result Unit Error =
         else failWithError "Expected empty but present runner status message, got: {format runnerStatus}"
 
         require Pass errorMsg = job.unsafe_getJobRunnerError
-        #require True = errorMsg ==* "Intentional runner error for testing"
-        #else failWithError "Unexpected runner error message: {errorMsg}"
-        require True = errorMsg ==* ""
-        else failWithError "Expected empty runner error message, got: {errorMsg}"
+        require True = errorMsg ==* "Intentional runner error for testing"
+        else failWithError "Unexpected runner error message: {errorMsg}"
 
         Pass Unit
 
@@ -143,6 +141,8 @@ export def testWrapperRunnerStatus _: Result Unit Error =
         def (Runner _ virtRun) = virtualRunner
         def result = virtRun job input
 
+        def _ = unsafe_reportJobRunnerError job "Inner runner printed error\n"
+
         # Set a runner error
         result
         | setRunnerOutputRunnerError (Some "Inner runner error".makeError)
@@ -160,7 +160,7 @@ export def testWrapperRunnerStatus _: Result Unit Error =
             Pass errorMsg if errorMsg !=* "" ->
                 # Add a prefix to the error message
                 def newErrorMsg = "WRAPPER: {errorMsg}"
-                #def _ = unsafe_reportJobRunnerError job newErrorMsg
+                def _ = unsafe_reportJobRunnerError job newErrorMsg
 
                 # Keep the same runner status (should be "Inner runner error" from inner runner)
                 result
@@ -188,16 +188,15 @@ export def testWrapperRunnerStatus _: Result Unit Error =
 
         # Verify the error message has been prefixed by the wrapper
         require Pass errorMsg = job.unsafe_getJobRunnerError
-        #require True = errorMsg ==* "Inner runner error\nWRAPPER: Inner runner error\n"
-        #else failWithError "Unexpected runner error message: {errorMsg}"
-        require True = errorMsg ==* ""
-        else failWithError "Expected empty runner error message, got: {errorMsg}"
+        require True = errorMsg ==* "Inner runner printed error\nWRAPPER: Inner runner printed error\n"
+        else failWithError "Unexpected runner error message: {errorMsg}"
 
         Pass Unit
 
     addErrorContext "wrapper-runner" check
 
 # Test that writes to different file descriptors to verify runner output/error capture
+# and proper ordering with runner-reported messages
 export def testFdOutputs _: Result Unit Error =
     # Create a temporary script that writes to fd 3 and fd 4
     require Pass scriptPath = writeTempFile "fd_test.sh" """
@@ -220,11 +219,32 @@ exit 0
         | getJobOutputs
         | addErrorContext "fd-outputs"
 
-    # Run the script with file descriptors 3 and 4 mapped to runner output and error
+    # Create a custom runner that reports messages before and after script execution
+    def run job input =
+        # Report runner messages before execution
+        def _ = unsafe_reportJobRunnerOutput job "RUNNER: Before execution\n"
+        def _ = unsafe_reportJobRunnerError job "RUNNER: Before execution error\n"
+
+        def (Runner _ virtRun) = localRunner
+        def result = virtRun job input
+
+        # Wait for job to complete
+        require None = result.getRunnerOutputRunnerError
+        else result
+
+        # Report runner messages after execution
+        def _ = unsafe_reportJobRunnerOutput job "RUNNER: After execution\n"
+        def _ = unsafe_reportJobRunnerError job "RUNNER: After execution error\n"
+
+        result
+
+    def testRunner = makeRunner "test-runner-fd-outputs" run
+
+    # Run with our custom runner
     def job =
         makeExecPlan (scriptPath.getPathName, Nil) (scriptPath, Nil)
         | editPlanEnvironment (setEnvironment "WAKE_ALLOW_RUNNER_STREAMS" "1")
-        | runJobWith localRunner
+        | runJobWith testRunner
 
     def check =
         # Wait for job to complete
@@ -241,11 +261,15 @@ exit 0
         require True = stderr ==* "This is standard error\n"
         else failWithError "Unexpected stderr: '{stderr}'"
 
-        require True = runnerOutput ==* "This is runner output\n"
-        else failWithError "Unexpected runner output: '{runnerOutput}'"
+        # Verify runner output contains messages in proper order: before, script fd3, after
+        def expectedRunnerOutput = "RUNNER: Before execution\nThis is runner output\nRUNNER: After execution\n"
+        require True = runnerOutput ==* expectedRunnerOutput
+        else failWithError "Unexpected runner output: '{runnerOutput}', expected: '{expectedRunnerOutput}'"
 
-        require True = runnerError ==* "This is runner error\n"
-        else failWithError "Unexpected runner error: '{runnerError}'"
+        # Verify runner error contains messages in proper order: before, script fd4, after
+        def expectedRunnerError = "RUNNER: Before execution error\nThis is runner error\nRUNNER: After execution error\n"
+        require True = runnerError ==* expectedRunnerError
+        else failWithError "Unexpected runner error: '{runnerError}', expected: '{expectedRunnerError}'"
 
         def _ = println "All file descriptor outputs verified successfully"
 
@@ -260,7 +284,7 @@ export def testRunnerCustomOutput _: Result Unit Error =
         def (Runner _ virtRun) = virtualRunner
         def result = virtRun job input
 
-        #def _ = unsafe_reportJobRunnerOutput job "Custom runner information: test data"
+        def _ = unsafe_reportJobRunnerOutput job "Custom runner information: test data"
 
         result
 
@@ -281,10 +305,8 @@ export def testRunnerCustomOutput _: Result Unit Error =
 
         # Verify the runner output contains our custom message
         require Pass runnerOutput = job.unsafe_getJobRunnerOutput
-        #require True = runnerOutput ==* "Custom runner information: test data"
-        #else failWithError "Unexpected runner output: '{runnerOutput}'"
-        require True = runnerOutput ==* ""
-        else failWithError "Expected empty runner output, got: '{runnerOutput}'"
+        require True = runnerOutput ==* "Custom runner information: test data"
+        else failWithError "Unexpected runner output: '{runnerOutput}'"
 
         require True = job.isJobOk
         else failWithError "Expected isJobOk to return True for job with custom runner output"

--- a/tests/standard-library/runner-outputs/test.wake
+++ b/tests/standard-library/runner-outputs/test.wake
@@ -1,16 +1,14 @@
 # Test cases for runner functionality including runner output, runner errors, and runner status
 
 # Test that a runner can fail a job even if the command succeeds
-export def testRunnerFailSuccess _: Result Unit Error =
+export def testRunnerFailWithEmptyError _: Result Unit Error =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
         def result = virtRun job input
 
         # Report a runner error after the job completes
-        def _ = unsafe_reportJobRunnerError job "Intentional runner error for testing"
-        def _ = unsafe_primJobSetRunnerStatus job 1
-
         result
+        #| setRunnerOutputRunnerError (Some "".makeError)
 
     def testRunner = makeRunner "test-runner-fail-success" run
 
@@ -19,17 +17,25 @@ export def testRunnerFailSuccess _: Result Unit Error =
         | runJobWith testRunner
 
     def check =
-        require False = job.isJobOk
-        else failWithError "Expected isJobOk to return False for job with runner error"
+        #require False = job.isJobOk
+        #else failWithError "Expected isJobOk to return False for job with runner error"
+        require True = job.isJobOk
+        else failWithError "Expected isJobOk to return True for successful job"
+        require Exited 0 = job.getJobStatus
+        else failWithError "Expected job status to be 0, got {format job.getJobStatus}"
 
-        # Runner status should be 1 (error) even though job status is 0 (success)
+        # Runner status should be Some even though the error message is empty
         require Pass runnerStatus = job.unsafe_getJobRunnerStatus
-        require True = runnerStatus == 1
-        else failWithError "Expected runner status 1, got {str runnerStatus}"
+        #require Some "" = runnerStatus
+        #else failWithError "Expected empty but present runner status message, got: '{format runnerStatus}'"
+        require None = runnerStatus
+        else failWithError "Expected None runner status for successful job, got '{format runnerStatus}'"
 
         require Pass errorMsg = job.unsafe_getJobRunnerError
-        require True = errorMsg ==* "Intentional runner error for testing"
-        else failWithError "Unexpected runner error message: {errorMsg}"
+        #require True = errorMsg ==* "Intentional runner error for testing"
+        #else failWithError "Unexpected runner error message: {errorMsg}"
+        require True = errorMsg ==* ""
+        else failWithError "Expected empty runner error message, got: {errorMsg}"
 
         Pass Unit
 
@@ -47,9 +53,8 @@ export def testRunnerFailWithJobFailure _: Result Unit Error =
         def result = baseRun job failingInput
 
         # Report a runner error after the job completes
-        def _ = unsafe_reportJobRunnerError job "Intentional runner error with job failure"
-
         result
+        | setRunnerOutputRunnerError (Some "Intentional runner error with job failure".makeError)
 
     def testRunner = makeRunner "test-runner-fail-with-job-failure" run
 
@@ -63,48 +68,21 @@ export def testRunnerFailWithJobFailure _: Result Unit Error =
         require Exited 42 = job.getJobStatus
         else failWithError "Expected job status 42, got {format job.getJobStatus}"
 
-        # Runner status should be independent of job status
+        # Runner status should be the given message since there was a runner error
         require Pass runnerStatus = job.unsafe_getJobRunnerStatus
-        require True = runnerStatus == 0
-        else failWithError "Expected runner status 0, got {str runnerStatus}"
+        require Some errorStatus = runnerStatus
+        else failWithError "Expected Some runner status, got None"
+        require True = errorStatus ==* "Intentional runner error with job failure"
+        else failWithError "Expected runner status to be 'Intentional runner error with job failure', got '{errorStatus}'"
 
-        # Runner error should be retrievable
+        # Runner error should not duplicate the status message
         require Pass errorMsg = job.unsafe_getJobRunnerError
-        require True = errorMsg ==* "Intentional runner error with job failure"
+        require True = errorMsg ==* ""
         else failWithError "Unexpected runner error message: {errorMsg}"
 
         Pass Unit
 
     addErrorContext "runner-fail-with-job-failure" check
-
-# Test that RunnerOutput correctly includes and propagates runner status
-export def testRunnerOutputStatus _: Result Unit Error =
-    # Create a custom runner that sets a specific runner status
-    def run job input =
-        def (Runner _ virtRun) = virtualRunner
-        def result = virtRun job input
-
-        # Set a specific runner status
-        def customStatus = 123
-        def _ = unsafe_primJobSetRunnerStatus job customStatus
-
-        result
-
-    def testRunner = makeRunner "test-runner-output-status" run
-
-    def job =
-        makeExecPlan ("<test>", "runner-output-status", Nil) Nil
-        | runJobWith testRunner
-
-    def check =
-        # Runner status should be what we set
-        require Pass runnerStatus = job.unsafe_getJobRunnerStatus
-        require True = runnerStatus == 123
-        else failWithError "Expected runner status 123, got {str runnerStatus}"
-
-        Pass Unit
-
-    addErrorContext "runner-output-status" check
 
 # Test that a runner can finish a job but mark it as failed
 export def testRunnerFailFinish _: Result Unit Error =
@@ -126,6 +104,15 @@ export def testRunnerFailFinish _: Result Unit Error =
         # Job should be marked as failed
         require False = job.isJobOk
         else failWithError "Expected isJobOk to return False for failing job"
+        require Exited 0 = job.getJobStatus
+        else failWithError "Expected job status to be 0, got {format job.getJobStatus}"
+
+        # Runner status should be the given message since a runner error is independent from job success
+        require Pass runnerStatus = job.unsafe_getJobRunnerStatus
+        require Some errorStatus = runnerStatus
+        else failWithError "Expected Some runner status, got None"
+        require True = errorStatus ==* "Mark job as failure"
+        else failWithError "Expected runner status to be 'Mark job as failure', got '{errorStatus}'"
 
         Pass Unit
 
@@ -142,10 +129,10 @@ export def testRunnerOkSuccess _: Result Unit Error =
         require True = job.isJobOk
         else failWithError "Expected isJobOk to return True for successful job"
 
-        # Runner status should be 0
+        # Runner status should be None (success)
         require Pass runnerStatus = job.unsafe_getJobRunnerStatus
-        require True = runnerStatus == 0
-        else failWithError "Expected runner status 0, got {str runnerStatus}"
+        require None = runnerStatus
+        else failWithError "Expected None runner status for successful job, got '{format runnerStatus}'"
 
         Pass Unit
 
@@ -159,13 +146,8 @@ export def testWrapperRunnerStatus _: Result Unit Error =
         def result = virtRun job input
 
         # Set a runner error
-        def _ = unsafe_reportJobRunnerError job "Inner runner error\n"
-
-        # Set a runner status
-        def customStatus = 42
-        def _ = unsafe_primJobSetRunnerStatus job customStatus
-
         result
+        | setRunnerOutputRunnerError (Some "Inner runner error".makeError)
 
     def innerRunner = makeRunner "inner-runner" innerRun
 
@@ -180,9 +162,9 @@ export def testWrapperRunnerStatus _: Result Unit Error =
             Pass errorMsg if errorMsg !=* "" ->
                 # Add a prefix to the error message
                 def newErrorMsg = "WRAPPER: {errorMsg}"
-                def _ = unsafe_reportJobRunnerError job newErrorMsg
+                #def _ = unsafe_reportJobRunnerError job newErrorMsg
 
-                # Keep the same runner status (should be 42 from inner runner)
+                # Keep the same runner status (should be "Inner runner error" from inner runner)
                 result
             _ ->
                 result
@@ -201,13 +183,17 @@ export def testWrapperRunnerStatus _: Result Unit Error =
 
         # Verify the runner status is preserved from the inner runner
         require Pass runnerStatus = job.unsafe_getJobRunnerStatus
-        require True = runnerStatus == 42
-        else failWithError "Expected runner status 42 from inner runner, got {str runnerStatus}"
+        require Some errorStatus = runnerStatus
+        else failWithError "Expected Some runner status, got None"
+        require True = errorStatus ==* "Inner runner error"
+        else failWithError "Expected runner status to be 'Inner runner error', got '{errorStatus}'"
 
         # Verify the error message has been prefixed by the wrapper
         require Pass errorMsg = job.unsafe_getJobRunnerError
-        require True = errorMsg ==* "Inner runner error\nWRAPPER: Inner runner error\n"
-        else failWithError "Unexpected runner error message: {errorMsg}"
+        #require True = errorMsg ==* "Inner runner error\nWRAPPER: Inner runner error\n"
+        #else failWithError "Unexpected runner error message: {errorMsg}"
+        require True = errorMsg ==* ""
+        else failWithError "Expected empty runner error message, got: {errorMsg}"
 
         Pass Unit
 
@@ -276,7 +262,7 @@ export def testRunnerCustomOutput _: Result Unit Error =
         def (Runner _ virtRun) = virtualRunner
         def result = virtRun job input
 
-        def _ = unsafe_reportJobRunnerOutput job "Custom runner information: test data"
+        #def _ = unsafe_reportJobRunnerOutput job "Custom runner information: test data"
 
         result
 
@@ -290,10 +276,17 @@ export def testRunnerCustomOutput _: Result Unit Error =
         # Wait for job to complete
         require Pass _ = job.getJobOutputs
 
+        # Runner status should be None since there was no runner error (just a print to the error stream)
+        require Pass runnerStatus = job.unsafe_getJobRunnerStatus
+        require None = runnerStatus
+        else failWithError "Expected None runner status for successful job, got '{format runnerStatus}'"
+
         # Verify the runner output contains our custom message
         require Pass runnerOutput = job.unsafe_getJobRunnerOutput
-        require True = runnerOutput ==* "Custom runner information: test data"
-        else failWithError "Unexpected runner output: '{runnerOutput}'"
+        #require True = runnerOutput ==* "Custom runner information: test data"
+        #else failWithError "Unexpected runner output: '{runnerOutput}'"
+        require True = runnerOutput ==* ""
+        else failWithError "Expected empty runner output, got: '{runnerOutput}'"
 
         require True = job.isJobOk
         else failWithError "Expected isJobOk to return True for job with custom runner output"

--- a/tests/standard-library/runner/test.wake
+++ b/tests/standard-library/runner/test.wake
@@ -1,7 +1,7 @@
 export def testRunnerFailFinish _ =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass _ = virtRun job (Pass input)
+        require Pass _ = virtRun job input
 
         # Force a failure outside of the actual job
         failWithError "Mark job as failure"

--- a/tests/standard-library/runner/test.wake
+++ b/tests/standard-library/runner/test.wake
@@ -1,10 +1,11 @@
 export def testRunnerFailFinish _ =
     def run job input =
         def (Runner _ virtRun) = virtualRunner
-        require Pass _ = virtRun job input
+        def result = virtRun job input
 
         # Force a failure outside of the actual job
-        failWithError "Mark job as failure"
+        result
+        | setRunnerOutputRunnerError (Some "Mark job as failure".makeError)
 
     def testRunner = makeRunner "" run
 

--- a/tools/wake-migrate/main.cpp
+++ b/tools/wake-migrate/main.cpp
@@ -175,8 +175,14 @@ static std::vector<Migration> get_migrations() {
          if (!exec_sql(db, "ALTER TABLE jobs_new RENAME TO jobs;")) return false;
 
          // Step 4: Recreate indexes
-         if (!exec_sql(db, "CREATE INDEX job on jobs(directory, commandline, environment, stdin, signature, keep, job_id, stat_id);")) return false;
-         if (!exec_sql(db, "CREATE INDEX runner_status_idx on jobs(runner_status) WHERE runner_status IS NOT NULL;")) return false;
+         if (!exec_sql(db,
+                       "CREATE INDEX job on jobs(directory, commandline, environment, stdin, "
+                       "signature, keep, job_id, stat_id);"))
+           return false;
+         if (!exec_sql(db,
+                       "CREATE INDEX runner_status_idx on jobs(runner_status) WHERE runner_status "
+                       "IS NOT NULL;"))
+           return false;
          if (!exec_sql(db, "CREATE INDEX jobstats on jobs(stat_id);")) return false;
 
          return true;

--- a/tools/wake-migrate/main.cpp
+++ b/tools/wake-migrate/main.cpp
@@ -128,6 +128,61 @@ static std::vector<Migration> get_migrations() {
        },
        "Add runner_status partial index"},
 
+      // Version 8 -> 9: Change runner_status from INTEGER to TEXT (nullable)
+      {8, 9,
+       [](sqlite3* db) -> bool {
+         // SQLite doesn't support ALTER COLUMN, so we need to recreate the table
+
+         // Step 1: Create new jobs table with TEXT runner_status
+         const char* create_new_table = R"(
+           CREATE TABLE jobs_new(
+             job_id      integer primary key autoincrement,
+             run_id      integer not null references runs(run_id),
+             use_id      integer not null references runs(run_id),
+             label       text    not null,
+             directory   text    not null,
+             commandline blob    not null,
+             environment blob    not null,
+             stdin       text    not null,
+             signature   integer not null,
+             stack       blob    not null,
+             stat_id     integer references stats(stat_id),
+             starttime   integer not null default 0,
+             endtime     integer not null default 0,
+             keep        integer not null default 0,
+             stale       integer not null default 0,
+             is_atty     integer not null default 0,
+             runner_status text
+           );
+         )";
+
+         if (!exec_sql(db, create_new_table)) return false;
+
+         // Step 2: Copy data, converting integer runner_status to text
+         // 0 -> NULL (success), non-zero -> string representation (failure)
+         const char* copy_data = R"(
+           INSERT INTO jobs_new SELECT
+             job_id, run_id, use_id, label, directory, commandline, environment,
+             stdin, signature, stack, stat_id, starttime, endtime, keep, stale, is_atty,
+             CASE WHEN runner_status = 0 THEN NULL ELSE 'Numeric return code ' || CAST(runner_status AS TEXT) END
+           FROM jobs;
+         )";
+
+         if (!exec_sql(db, copy_data)) return false;
+
+         // Step 3: Drop old table and rename new one
+         if (!exec_sql(db, "DROP TABLE jobs;")) return false;
+         if (!exec_sql(db, "ALTER TABLE jobs_new RENAME TO jobs;")) return false;
+
+         // Step 4: Recreate indexes
+         if (!exec_sql(db, "CREATE INDEX job on jobs(directory, commandline, environment, stdin, signature, keep, job_id, stat_id);")) return false;
+         if (!exec_sql(db, "CREATE INDEX runner_status_idx on jobs(runner_status) WHERE runner_status IS NOT NULL;")) return false;
+         if (!exec_sql(db, "CREATE INDEX jobstats on jobs(stat_id);")) return false;
+
+         return true;
+       },
+       "Convert runner_status from INTEGER to TEXT"},
+
   };
 }
 

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -89,7 +89,7 @@ static void describe_metadata(const std::vector<JobReflection> &jobs, bool debug
         << "  In  bytes:     " << job.usage.ibytes << std::endl
         << "  Out bytes:     " << job.usage.obytes << std::endl
         << "  Status:        " << job.usage.status << std::endl
-        << "  Runner Status: " << job.runner_status << std::endl
+        << "  Runner Status: " << (job.runner_status.first ? job.runner_status.second : "success") << std::endl
         << "  Stdin:         " << job.stdin_file << std::endl;
     if (verbose) {
       out << "  Wake run:  " << job.wake_start.as_string() << " (" << job.wake_cmdline << ")"
@@ -200,7 +200,7 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
         << "#   In  bytes:     " << job.usage.ibytes << std::endl
         << "#   Out bytes:     " << job.usage.obytes << std::endl
         << "#   Status:        " << job.usage.status << std::endl
-        << "#   Runner Status: " << job.runner_status << std::endl;
+        << "#   Runner Status: " << (job.runner_status.first ? job.runner_status.second : "success") << std::endl;
     if (verbose) {
       out << "#  Wake run:  " << job.wake_start.as_string() << " (" << job.wake_cmdline << ")"
           << std::endl;

--- a/tools/wake/describe.cpp
+++ b/tools/wake/describe.cpp
@@ -89,7 +89,8 @@ static void describe_metadata(const std::vector<JobReflection> &jobs, bool debug
         << "  In  bytes:     " << job.usage.ibytes << std::endl
         << "  Out bytes:     " << job.usage.obytes << std::endl
         << "  Status:        " << job.usage.status << std::endl
-        << "  Runner Status: " << (job.runner_status.first ? job.runner_status.second : "success") << std::endl
+        << "  Runner Status: " << (job.runner_status.first ? job.runner_status.second : "success")
+        << std::endl
         << "  Stdin:         " << job.stdin_file << std::endl;
     if (verbose) {
       out << "  Wake run:  " << job.wake_start.as_string() << " (" << job.wake_cmdline << ")"
@@ -200,7 +201,8 @@ static void describe_shell(const std::vector<JobReflection> &jobs, bool debug, b
         << "#   In  bytes:     " << job.usage.ibytes << std::endl
         << "#   Out bytes:     " << job.usage.obytes << std::endl
         << "#   Status:        " << job.usage.status << std::endl
-        << "#   Runner Status: " << (job.runner_status.first ? job.runner_status.second : "success") << std::endl;
+        << "#   Runner Status: " << (job.runner_status.first ? job.runner_status.second : "success")
+        << std::endl;
     if (verbose) {
       out << "#  Wake run:  " << job.wake_start.as_string() << " (" << job.wake_cmdline << ")"
           << std::endl;

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -209,7 +209,7 @@ void query_jobs(const CommandLineOptions &clo, Database &db) {
 
   // --failed
   if (clo.failed) {
-    collect_ands.push_back({"(status <> 0 OR runner_status <> 0)"});
+    collect_ands.push_back({"(status <> 0 OR runner_status IS NOT NULL)"});
   }
 
   // --canceled


### PR DESCRIPTION
Recent changes I made to a runner (to provide a more debuggable error message than just listing the exit code) reminded me that in order to do so without dropping perfectly valid information about the Job, we had to rely on the `unsafe_setJobRunnerStatus` state manipulation.  Jumping ahead in time, as I wrote this patch I realized that we don't have to stick to the opaque exit-code model that I had just fixed since we're working in (more or less) a single environment with the ability to use richer types.  This fixes the first by *always* returning the full RunnerOutput tuple from runner functions (occasionally with an error attached), and fixes the second by using String messages which are set inline within the Runner itself rather than ints which have to be interpreted later.  It also fixes a miscellaneous bug or two along the way; the only one that comes to mind at the moment is `unsafe_reportJobRunner(Output|Error)` preemptively marking their respective streams as closed, which only worked previously because we only ever used them in runners which unconditionally failed to begin with -- relatedly, the biggest non-Runner-internal change is that `prim_job_fail_finish` is removed and *every* job (successful or not) goes through `prim_job_finish`, which is a nice degree of logic consistency.

I highly recommend reviewing this one or two commits at a time.  The history isn't always *completely* clean, but each of them are still decently topical, and it's not always obvious from the combined diff what was changed due to what.