### PR TITLE
wake --attach

### DIFF
--- a/share/doc/wake/workspace-virtualization-and-multi-wake.md
+++ b/share/doc/wake/workspace-virtualization-and-multi-wake.md
@@ -43,6 +43,8 @@ Some things this makes possible:
   projection of wake state.
 - [Running Multiple Wake Invocations Concurrently](workspace-virtualization/concurrent-invocations.md)
   — how concurrent runs coordinate, and options for observing active runs.
+- [Inspecting a Live Job](workspace-virtualization/inspecting-live-jobs.md)
+  — attaching to a running job and accessing its host-visible live workspace.
 - [Managing Workspace Disk Usage with CAS](workspace-virtualization/managing-disk-usage.md)
   — reclaiming space with `--prune`, `--rm`, and staging cleanup.
 - [Known Limitations and Good to Know](workspace-virtualization/limitations.md).

--- a/share/doc/wake/workspace-virtualization/concurrent-invocations.md
+++ b/share/doc/wake/workspace-virtualization/concurrent-invocations.md
@@ -19,6 +19,10 @@ builds:
 | ------------- | -------------------------------------------------------------------- |
 | `--history`   | Report the command-line history of all wake commands, including completed and in-flight runs. |
 | `--ps`        | Show jobs currently running in active wake builds, grouped by run. Each job lists its id, elapsed time (or `[queued]` if not yet started), and label. |
+| `--attach JOB` | Open a shell in a running FUSE-sandboxed job's live workspace view. |
+
+For details on attaching to a job and using its host-visible FUSE workspace,
+see [Inspecting a Live Job](inspecting-live-jobs.md).
 
 ### Example: watching jobs across concurrent runs
 

--- a/share/doc/wake/workspace-virtualization/inspecting-live-jobs.md
+++ b/share/doc/wake/workspace-virtualization/inspecting-live-jobs.md
@@ -1,0 +1,34 @@
+# Inspecting a Live Job
+
+_Part of [Workspace Virtualization and Multiple Wake Invocations](../workspace-virtualization-and-multi-wake.md)._
+
+Use `wake --ps` to find a running job ID:
+
+```
+$ wake --ps
+Run 12: wake -x 'buildEverything Unit'
+  JOB     ELAPSED     LABEL
+  341     [1m12s]     compile core/main.cpp
+  342     [1m04s]     compile core/util.cpp
+  348     [queued]    link core
+```
+
+Then attach a shell to job `341`'s live FUSE-sandboxed workspace:
+
+```
+wake --attach 341
+```
+
+The attached shell is read/write: changes to the workspace affect the running
+job and can change its build result. Its banner also prints the host-visible
+FUSE root for the job's live workspace. Use a host-installed external tool
+against a workspace-relative live file below that root, for example:
+
+```
+fuse_root=/scratch/user/workspace/.fuse/uid.gid/job-pid
+vim -R "$fuse_root/build/output"
+```
+
+The FUSE path presents live staging data under its real workspace-relative
+names. It remains valid only while the job is running. It is the same writable
+view used by the job, so do not modify it: writes can affect the build result.

--- a/share/doc/wake/workspace-virtualization/inspecting-live-jobs.md
+++ b/share/doc/wake/workspace-virtualization/inspecting-live-jobs.md
@@ -13,6 +13,10 @@ Run 12: wake -x 'buildEverything Unit'
   348     [queued]    link core
 ```
 
+When this list is large, combine `--ps` with the other job filters, especially
+`--label`, to narrow it. Other useful filters include `--input`, `--output`,
+`--tag`, and `--job`.
+
 Then attach a shell to job `341`'s live FUSE-sandboxed workspace:
 
 ```

--- a/share/doc/wake/workspace-virtualization/limitations.md
+++ b/share/doc/wake/workspace-virtualization/limitations.md
@@ -33,11 +33,15 @@ _Part of [Workspace Virtualization and Multiple Wake Invocations](../workspace-v
   - `wake --ps` lists jobs currently running across all active builds, grouped
     by run, with each job's id, elapsed time (or `[queued]`), and label. Use it
     to find the id of the job you want to inspect.
-  - `wake --job <jobID> -v` describes a specific job in verbose form, including
-    its command-line, environment, working directory, and any stdout/stderr
-    streamed so far.
+   - `wake --job <jobID> -v` describes a specific job in verbose form, including
+     its command-line, environment, working directory, and any stdout/stderr
+     streamed so far.
+   - `wake --attach <jobID>` opens a read/write shell in a FUSE-sandboxed job's
+     live filesystem view, including its in-progress outputs at their real
+     workspace paths. Its banner prints the host-visible FUSE root for that
+     job, which host-installed tools can use to read a live file by its
+     workspace-relative path.
 
-  These options let you watch a job's command and streamed output, but they do
-  *not* expose the job's not-yet-completed output files, since those are not
-  materialized until the job finishes. Inspecting the in-progress build outputs
-  of a long-running job is something the Wake team is actively looking into.
+    Attach is available only for a live FUSE-sandboxed job run by the same user.
+    Its shell and the host-visible FUSE path both use the job's live writable
+    workspace, so changes through either can affect the build result.

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -587,8 +587,9 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   const char *sql_clear_live_job = "delete from live_jobs where job_id = ?";
   const char *sql_clear_live_jobs_by_run = "delete from live_jobs where run_id = ?";
   const char *sql_get_live_job =
-      "select lj.pid, j.directory from live_jobs lj"
+      "select lj.pid, lj.run_id, j.directory from live_jobs lj"
       " join jobs j on lj.job_id = j.job_id"
+      " join runs r on lj.run_id = r.run_id and r.end_time is null"
       " where lj.job_id = ?";
 
 #define PREPARE(sql, member)                                                                     \
@@ -2854,11 +2855,18 @@ std::optional<LiveJobInfo> Database::get_live_job(long job_id) const {
   std::optional<LiveJobInfo> out;
   if (sqlite3_step(imp->get_live_job) == SQLITE_ROW) {
     out = LiveJobInfo{static_cast<pid_t>(sqlite3_column_int64(imp->get_live_job, 0)),
-                       rip_column(imp->get_live_job, 1)};
+                      sqlite3_column_int64(imp->get_live_job, 1), rip_column(imp->get_live_job, 2)};
   }
   finish_stmt(why, imp->get_live_job, imp->debugdb);
   end_txn();
   return out;
+}
+
+bool Database::is_live_run(long run_id) const {
+  for (const auto &run : get_runs()) {
+    if (run.id == run_id) return !run.end_time && RunLockProbe::is_live(run_id);
+  }
+  return false;
 }
 
 std::vector<std::pair<std::string, int>> Database::get_interleaved_output(long job_id) const {

--- a/src/runtime/database.cpp
+++ b/src/runtime/database.cpp
@@ -117,6 +117,10 @@ struct Database::detail {
   sqlite3_stmt *clear_run_files;
   sqlite3_stmt *set_starttime;
   sqlite3_stmt *get_dead_hashes;
+  sqlite3_stmt *insert_live_job;
+  sqlite3_stmt *clear_live_job;
+  sqlite3_stmt *clear_live_jobs_by_run;
+  sqlite3_stmt *get_live_job;
 
   long run_id;
   long gc_watermark;
@@ -180,6 +184,10 @@ struct Database::detail {
         clear_run_files(0),
         set_starttime(0),
         get_dead_hashes(0),
+        insert_live_job(0),
+        clear_live_job(0),
+        clear_live_jobs_by_run(0),
+        get_live_job(0),
         run_id(0),
         gc_watermark(0) {}
 };
@@ -574,6 +582,14 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
       "select d.hash from disk_batch d where d.hash is not null and not exists ("
       "  select 1 from files where hash=d.hash and deleted=0"
       ")";
+  const char *sql_insert_live_job =
+      "insert or replace into live_jobs(job_id, run_id, pid) values(?, ?, ?)";
+  const char *sql_clear_live_job = "delete from live_jobs where job_id = ?";
+  const char *sql_clear_live_jobs_by_run = "delete from live_jobs where run_id = ?";
+  const char *sql_get_live_job =
+      "select lj.pid, j.directory from live_jobs lj"
+      " join jobs j on lj.job_id = j.job_id"
+      " where lj.job_id = ?";
 
 #define PREPARE(sql, member)                                                                     \
   ret = sqlite3_prepare_v2(imp->db, sql, -1, &imp->member, 0);                                   \
@@ -639,6 +655,10 @@ std::string Database::open(bool wait, bool memory, bool tty, bool readonly) {
   PREPARE(sql_clear_run_files, clear_run_files);
   PREPARE(sql_set_starttime, set_starttime);
   PREPARE(sql_get_dead_hashes, get_dead_hashes);
+  PREPARE(sql_insert_live_job, insert_live_job);
+  PREPARE(sql_clear_live_job, clear_live_job);
+  PREPARE(sql_clear_live_jobs_by_run, clear_live_jobs_by_run);
+  PREPARE(sql_get_live_job, get_live_job);
 
   return "";
 }
@@ -713,6 +733,10 @@ void Database::close() {
   FINALIZE(clear_run_files);
   FINALIZE(set_starttime);
   FINALIZE(get_dead_hashes);
+  FINALIZE(insert_live_job);
+  FINALIZE(clear_live_job);
+  FINALIZE(clear_live_jobs_by_run);
+  FINALIZE(get_live_job);
 
   imp->run_lock.reset();
 
@@ -928,6 +952,9 @@ void Database::finish_run() {
   single_step(why, imp->set_run_end_time, imp->debugdb);
   bind_integer(why, imp->clear_run_files, 1, imp->run_id);
   single_step("Could not clear run_files for finished run", imp->clear_run_files, imp->debugdb);
+  bind_integer(why, imp->clear_live_jobs_by_run, 1, imp->run_id);
+  single_step("Could not clear live_jobs for finished run", imp->clear_live_jobs_by_run,
+              imp->debugdb);
   end_txn();
 
   // Remove our own lock file - we're done with this run
@@ -975,6 +1002,9 @@ void Database::reap_dead_runs() {
       single_step(why, imp->set_run_end_time, imp->debugdb);
       bind_integer(why, imp->clear_run_files, 1, dead_run);
       single_step("Could not clear run_files for dead run", imp->clear_run_files, imp->debugdb);
+      bind_integer(why, imp->clear_live_jobs_by_run, 1, dead_run);
+      single_step("Could not clear live_jobs for dead run", imp->clear_live_jobs_by_run,
+                  imp->debugdb);
     }
     end_txn();
   }
@@ -1422,6 +1452,9 @@ void Database::finish_job(long job, const std::string &inputs, const std::string
 
   const char *why = "Could not save job inputs and outputs";
   begin_rw_txn();
+
+  bind_integer(why, imp->clear_live_job, 1, job);
+  single_step(why, imp->clear_live_job, imp->debugdb);
 
   bind_integer(why, imp->add_stats, 1, hashcode);
   bind_integer(why, imp->add_stats, 2, reality.status);
@@ -2798,6 +2831,34 @@ void Database::start_job(long job, int64_t starttime) {
   bind_integer(why, imp->set_starttime, 2, job);
   single_step(why, imp->set_starttime, imp->debugdb);
   end_txn();
+}
+
+void Database::start_job(long job, int64_t starttime, pid_t pid) {
+  const char *why = "Could not record job start time";
+  begin_rw_txn();
+  bind_integer(why, imp->set_starttime, 1, starttime);
+  bind_integer(why, imp->set_starttime, 2, job);
+  single_step(why, imp->set_starttime, imp->debugdb);
+  why = "Could not record live job pid";
+  bind_integer(why, imp->insert_live_job, 1, job);
+  bind_integer(why, imp->insert_live_job, 2, imp->run_id);
+  bind_integer(why, imp->insert_live_job, 3, pid);
+  single_step(why, imp->insert_live_job, imp->debugdb);
+  end_txn();
+}
+
+std::optional<LiveJobInfo> Database::get_live_job(long job_id) const {
+  const char *why = "Could not query live job";
+  begin_ro_txn();
+  bind_integer(why, imp->get_live_job, 1, job_id);
+  std::optional<LiveJobInfo> out;
+  if (sqlite3_step(imp->get_live_job) == SQLITE_ROW) {
+    out = LiveJobInfo{static_cast<pid_t>(sqlite3_column_int64(imp->get_live_job, 0)),
+                       rip_column(imp->get_live_job, 1)};
+  }
+  finish_stmt(why, imp->get_live_job, imp->debugdb);
+  end_txn();
+  return out;
 }
 
 std::vector<std::pair<std::string, int>> Database::get_interleaved_output(long job_id) const {

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -18,6 +18,8 @@
 #ifndef DATABASE_H
 #define DATABASE_H
 
+#include <sys/types.h>
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -90,6 +92,12 @@ struct OpenRunJobReflection {
   long job_id;
   std::string label;
   int64_t starttime;  // 0 = queued (not yet forked), non-zero = wall-clock ns at fork
+};
+
+// Host pid + working directory of a currently-running job, for `wake --attach`.
+struct LiveJobInfo {
+  pid_t pid;
+  std::string directory;
 };
 
 struct JobReflection {
@@ -193,6 +201,11 @@ struct Database {
       long *job);  // key used for accesses below
 
   void start_job(long job, int64_t starttime);  // record wall-clock start time eagerly
+  // Like above, but also records the host pid of the just-forked runner process
+  // in live_jobs, for `wake --attach`. Use for real (forked) jobs only.
+  void start_job(long job, int64_t starttime, pid_t pid);
+  // Returns the recorded pid + working directory for a still-running job, if any.
+  std::optional<LiveJobInfo> get_live_job(long job_id) const;
   void finish_job(long job,
                   const std::string &inputs,       // null separated
                   const std::string &outputs,      // null separated

--- a/src/runtime/database.h
+++ b/src/runtime/database.h
@@ -94,9 +94,10 @@ struct OpenRunJobReflection {
   int64_t starttime;  // 0 = queued (not yet forked), non-zero = wall-clock ns at fork
 };
 
-// Host pid + working directory of a currently-running job, for `wake --attach`.
+// Host pid, run, and working directory of a currently-running job.
 struct LiveJobInfo {
   pid_t pid;
+  long run_id;
   std::string directory;
 };
 
@@ -204,8 +205,10 @@ struct Database {
   // Like above, but also records the host pid of the just-forked runner process
   // in live_jobs, for `wake --attach`. Use for real (forked) jobs only.
   void start_job(long job, int64_t starttime, pid_t pid);
-  // Returns the recorded pid + working directory for a still-running job, if any.
+  // Returns the recorded pid, run, and working directory for a still-running job, if any.
   std::optional<LiveJobInfo> get_live_job(long job_id) const;
+  // True when the run is unfinished and its owning wake process still holds its lock.
+  bool is_live_run(long run_id) const;
   void finish_job(long job,
                   const std::string &inputs,       // null separated
                   const std::string &outputs,      // null separated

--- a/src/runtime/job.cpp
+++ b/src/runtime/job.cpp
@@ -908,7 +908,7 @@ static void launch(JobTable *jobtable) {
     entry->job->state |= STATE_FORKED;
     int64_t starttime_ns =
         (int64_t)entry->job->start.tv_sec * 1000000000LL + entry->job->start.tv_nsec;
-    jobtable->imp->db->start_job(entry->job->job, starttime_ns);
+    jobtable->imp->db->start_job(entry->job->job, starttime_ns, pid);
     close(stdout_stream[1]);
     close(stderr_stream[1]);
     close(runner_out_stream[1]);

--- a/src/runtime/schema.h
+++ b/src/runtime/schema.h
@@ -1,7 +1,7 @@
 #ifndef WAKE_SCHEMA_H
 #define WAKE_SCHEMA_H
 
-#define SCHEMA_VERSION "16"
+#define SCHEMA_VERSION "17"
 
 // Per-connection settings to always apply.  Do this first!
 inline const char *getCommonPragmaSQL() {
@@ -114,6 +114,11 @@ inline const char *getWakeSchemaSQLTxn() {
          "  file_id integer not null references files(file_id) on delete cascade,"
          "  primary key(file_id, run_id));"
          "create index if not exists run_files_by_run on run_files(run_id, file_id);"
+         "create table if not exists live_jobs("
+         "  job_id integer primary key references jobs(job_id) on delete cascade,"
+         "  run_id integer not null references runs(run_id) on delete cascade,"
+         "  pid    integer not null);"
+         "create index if not exists live_jobs_by_run on live_jobs(run_id, job_id);"
          // clang-format off
          "insert or ignore into schema(version) values(" SCHEMA_VERSION ");"
          "pragma user_version=" SCHEMA_VERSION ";"

--- a/tools/wake-migrate/main.cpp
+++ b/tools/wake-migrate/main.cpp
@@ -534,6 +534,21 @@ static std::vector<Migration> get_migrations() {
          return false;
        },
        "Hash algorithm changed from BLAKE2b to BLAKE3; requires a fresh database."},
+
+      // Version 16 -> 17: Add live_jobs table tracking the host pid of running jobs,
+      // used by `wake --attach`. No backfill needed: only populated by active runs.
+      {16, 17,
+       [](sqlite3* db) -> bool {
+         if (!exec_sql(db,
+                       "CREATE TABLE IF NOT EXISTS live_jobs("
+                       "  job_id integer primary key references jobs(job_id) on delete cascade,"
+                       "  run_id integer not null references runs(run_id) on delete cascade,"
+                       "  pid    integer not null);"))
+           return false;
+         return exec_sql(
+             db, "CREATE INDEX IF NOT EXISTS live_jobs_by_run ON live_jobs(run_id, job_id);");
+       },
+       "Add live_jobs table tracking host pid of running jobs for wake --attach"},
   };
 }
 

--- a/tools/wake/attach.cpp
+++ b/tools/wake/attach.cpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "attach.h"
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sched.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+
+namespace {
+
+// Retry budget for waiting on the sandboxed payload to fork and unshare its
+// namespaces (there's a short window right after wakebox forks it).
+constexpr int kPayloadRetries = 40;
+constexpr int kPayloadRetryDelayUs = 50000;  // 50ms * 40 = 2s
+
+std::string read_comm(pid_t pid) {
+  FILE *f = fopen(("/proc/" + std::to_string(pid) + "/comm").c_str(), "r");
+  if (!f) return "";
+  char buf[64] = {};
+  if (!fgets(buf, sizeof(buf), f)) buf[0] = 0;
+  fclose(f);
+  std::string comm(buf);
+  while (!comm.empty() && comm.back() == '\n') comm.pop_back();
+  return comm;
+}
+
+// Parses ppid (field 4) out of /proc/<pid>/stat, skipping past the "(comm)"
+// field by scanning to the last ')' -- comm can itself contain spaces/parens.
+std::optional<pid_t> read_ppid(pid_t pid) {
+  FILE *f = fopen(("/proc/" + std::to_string(pid) + "/stat").c_str(), "r");
+  if (!f) return std::nullopt;
+  char buf[4096];
+  size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+  fclose(f);
+  buf[n] = 0;
+
+  char *rparen = strrchr(buf, ')');
+  int ppid = 0;
+  if (!rparen || sscanf(rparen + 1, " %*c %d", &ppid) != 1) return std::nullopt;
+  return ppid;
+}
+
+std::optional<std::string> read_ns_link(pid_t pid, const char *ns) {
+  std::string path = "/proc/" + std::to_string(pid) + "/ns/" + ns;
+  char buf[256];
+  ssize_t n = readlink(path.c_str(), buf, sizeof(buf) - 1);
+  if (n < 0) return std::nullopt;
+  return std::string(buf, n);
+}
+
+// Find the direct child of `wakebox_main_pid` that has entered its own mount
+// namespace -- that's the FUSE-sandboxed payload (wakebox-main itself stays in
+// the host mount namespace). Excludes the wb-timer sibling (only present when
+// a command timeout is configured), which never unshares and would otherwise
+// be mistaken for the payload. Retries briefly to cover the race where the
+// payload hasn't forked/unshared yet.
+//
+// This is the caller's own job, so /proc is fully visible; no privilege or
+// CAP_SYS_PTRACE is needed to read /proc/<pid>/ns/*.
+std::optional<pid_t> resolve_payload_pid(pid_t wakebox_main_pid) {
+  auto main_mnt_ns = read_ns_link(wakebox_main_pid, "mnt");
+  if (!main_mnt_ns) return std::nullopt;
+
+  for (int attempt = 0; attempt < kPayloadRetries; ++attempt) {
+    DIR *proc = opendir("/proc");
+    if (!proc) return std::nullopt;
+
+    std::optional<pid_t> found;
+    struct dirent *entry;
+    while ((entry = readdir(proc)) != nullptr) {
+      char *end = nullptr;
+      long candidate = strtol(entry->d_name, &end, 10);
+      if (end == entry->d_name || *end != '\0' || candidate <= 0) continue;  // not a pid dir
+      pid_t candidate_pid = static_cast<pid_t>(candidate);
+
+      auto ppid = read_ppid(candidate_pid);
+      if (!ppid || *ppid != wakebox_main_pid) continue;
+      if (read_comm(candidate_pid) == "wb-timer") continue;
+
+      auto mnt_ns = read_ns_link(candidate_pid, "mnt");
+      if (mnt_ns && *mnt_ns != *main_mnt_ns) {
+        found = candidate_pid;
+        break;
+      }
+    }
+    closedir(proc);
+    if (found) return found;
+    usleep(kPayloadRetryDelayUs);
+  }
+  return std::nullopt;
+}
+
+bool setns_path(const std::string &path, int nstype) {
+  int fd = open(path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    std::cerr << "wake --attach: open(" << path << "): " << strerror(errno) << std::endl;
+    return false;
+  }
+  bool ok = setns(fd, nstype) == 0;
+  if (!ok) std::cerr << "wake --attach: setns(" << path << "): " << strerror(errno) << std::endl;
+  close(fd);
+  return ok;
+}
+
+}  // namespace
+
+int attach_job(Database &db, long job_id) {
+  auto info = db.get_live_job(job_id);
+  if (!info) {
+    std::cerr << "wake --attach: job " << job_id
+              << " is not currently running (unknown job id, or already finished)" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // kill(pid, 0) with signal 0 only probes for existence/permission, it
+  // sends nothing. ESRCH means the pid is really gone (stale record from a
+  // crashed run). EPERM means it exists but belongs to another uid -- attach
+  // only supports the owning user (only the owner's euid satisfies the
+  // kernel's setns ownership check without privilege), so that's an error too.
+  if (kill(info->pid, 0) != 0) {
+    if (errno == ESRCH) {
+      std::cerr << "wake --attach: job " << job_id
+                << "'s process is no longer running (stale record from a crashed run -- run "
+                   "'wake' or 'wake --clean' to reap it)"
+                << std::endl;
+    } else {
+      std::cerr << "wake --attach: job " << job_id
+                << " belongs to another user; attach only supports jobs you launched" << std::endl;
+    }
+    return EXIT_FAILURE;
+  }
+
+  // The recorded pid is wakebox-main, which stays in the host namespaces. The
+  // FUSE-sandboxed view lives in its payload child (the one that unshared into
+  // its own mount namespace); resolve that before entering anything.
+  auto payload_pid = resolve_payload_pid(info->pid);
+  if (!payload_pid) {
+    std::cerr << "wake --attach: could not find a sandboxed process for job " << job_id
+              << " -- it may not have been run under the FUSE sandbox runner, or the sandbox "
+                 "hasn't started yet"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const char *shell = getenv("SHELL");
+  if (!shell || !*shell) shell = "/bin/sh";
+
+  // fork(): the child is single-threaded regardless of how many threads wake
+  // has, which is exactly what setns(CLONE_NEWUSER) requires. No privileged
+  // helper is needed -- the caller owns the job, so its euid matches the
+  // sandbox's user-namespace owner and the kernel permits the setns with no
+  // capabilities at all. The view is read/write (writes land in the same FUSE
+  // staging the job itself writes to); guaranteeing read-only would require
+  // CAP_SYS_ADMIN the owner doesn't have here (see the design doc's revision).
+  pid_t child = fork();
+  if (child < 0) {
+    std::cerr << "wake --attach: fork: " << strerror(errno) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (child == 0) {
+    std::string ns_dir = "/proc/" + std::to_string(*payload_pid) + "/ns/";
+    std::string cwd_link = "/proc/" + std::to_string(*payload_pid) + "/cwd";
+
+    // Grab the job's working directory as an fd *before* entering the sandbox.
+    // The workspace can be mounted at an arbitrary path inside the sandbox
+    // (e.g. /workspace under a container rootfs, not the host workspace path),
+    // so a guessed absolute path is wrong in general. /proc/<payload>/cwd is a
+    // magic symlink the kernel resolves straight to the job's cwd dentry --
+    // openable here even though that path isn't reachable from our mount ns --
+    // and fchdir()ing it after setns lands us exactly where the job is. Also
+    // read its path string (as seen inside the sandbox) purely for the notice.
+    char cwd_path[PATH_MAX];
+    ssize_t n = readlink(cwd_link.c_str(), cwd_path, sizeof(cwd_path) - 1);
+    std::string cwd_display = n > 0 ? std::string(cwd_path, n) : "the job's working directory";
+    int cwd_fd = open(cwd_link.c_str(), O_RDONLY | O_DIRECTORY);
+    if (cwd_fd < 0) {
+      std::cerr << "wake --attach: open(" << cwd_link << "): " << strerror(errno) << std::endl;
+      _exit(EXIT_FAILURE);
+    }
+
+    // User namespace first (grants CAP_SYS_ADMIN within it, which the
+    // subsequent mount-namespace setns requires), then the mount namespace.
+    if (!setns_path(ns_dir + "user", CLONE_NEWUSER) || !setns_path(ns_dir + "mnt", CLONE_NEWNS))
+      _exit(EXIT_FAILURE);
+
+    // setns(CLONE_NEWNS) resets cwd to the new namespace's root; fchdir back to
+    // the job's own working directory via the fd captured above.
+    if (fchdir(cwd_fd) != 0) {
+      std::cerr << "wake --attach: could not enter the job's working directory (" << cwd_display
+                << "): " << strerror(errno) << std::endl;
+      _exit(EXIT_FAILURE);
+    }
+    close(cwd_fd);
+
+    std::cerr << "wake --attach: read/write shell in the live sandbox of job " << job_id
+              << " (pid " << *payload_pid << ", cwd " << cwd_display
+              << "); writes go to the job's in-progress outputs" << std::endl;
+
+    execl(shell, shell, nullptr);
+    std::cerr << "wake --attach: exec(" << shell << "): " << strerror(errno) << std::endl;
+    _exit(EXIT_FAILURE);
+  }
+
+  int status = 0;
+  if (waitpid(child, &status, 0) != child) {
+    std::cerr << "wake --attach: waitpid: " << strerror(errno) << std::endl;
+    return EXIT_FAILURE;
+  }
+  return WIFEXITED(status) ? WEXITSTATUS(status) : EXIT_FAILURE;
+}

--- a/tools/wake/attach.cpp
+++ b/tools/wake/attach.cpp
@@ -206,19 +206,22 @@ int attach_job(Database &db, long job_id) {
     }
     close(cwd_fd);
 
-    std::cerr
-        << "+------------------------------------------------------------------+\n"
-        << warning_line("Attached to the live sandbox for Wake job " + std::to_string(job_id))
-        << '\n'
-        << warning_line("Payload PID: " + std::to_string(*payload_pid) + "  CWD: " + cwd_display)
-        << '\n'
-        << warning_line("Host FUSE live workspace:") << '\n'
-        << warning_line(host_live_workspace) << '\n'
-        << warning_line("") << '\n'
-        << warning_line("WARNING: This shell and the host FUSE workspace are read/write.") << '\n'
-        << warning_line("Any changes you make affect the in-progress job and may change") << '\n'
-        << warning_line("the build result.") << '\n'
-        << "+------------------------------------------------------------------+" << std::endl;
+    std::cerr << "+------------------------------------------------------------------+\n"
+              << warning_line("Attached to the live sandbox for Wake job " + std::to_string(job_id))
+              << '\n'
+              << warning_line("Payload PID: " + std::to_string(*payload_pid) +
+                              "  CWD: " + cwd_display)
+              << '\n'
+              << warning_line("Host FUSE live workspace:") << '\n'
+              << warning_line(host_live_workspace) << '\n'
+              << warning_line("") << '\n'
+              << warning_line("WARNING: This shell and the host FUSE workspace are read/write.")
+              << '\n'
+              << warning_line("Any changes you make affect the in-progress job and may change")
+              << '\n'
+              << warning_line("the build result.") << '\n'
+              << "+------------------------------------------------------------------+"
+              << std::endl;
 
     execl(shell, shell, nullptr);
     std::cerr << "wake --attach: exec(" << shell << "): " << strerror(errno) << std::endl;

--- a/tools/wake/attach.cpp
+++ b/tools/wake/attach.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SiFive, Inc.
+ * Copyright 2026 SiFive, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,6 +165,10 @@ int attach_job(Database &db, long job_id) {
   const char *shell = getenv("SHELL");
   if (!shell || !*shell) shell = "/bin/sh";
 
+  std::string host_live_workspace = std::filesystem::current_path().string() + "/.fuse/" +
+                                    std::to_string(getuid()) + "." + std::to_string(getgid()) +
+                                    "/" + std::to_string(info->pid);
+
   // setns(CLONE_NEWUSER) requires a single-threaded process, so enter the
   // namespaces from a forked child. The attached view is read/write.
   pid_t child = fork();
@@ -202,17 +206,21 @@ int attach_job(Database &db, long job_id) {
     }
     close(cwd_fd);
 
-    std::cerr << "+------------------------------------------------------------------+\n"
-              << warning_line("Attached to the live sandbox for Wake job " + std::to_string(job_id))
-              << '\n'
-              << warning_line("PID: " + std::to_string(*payload_pid) + "  CWD: " + cwd_display)
-              << '\n'
-              << warning_line("") << '\n'
-              << warning_line("WARNING: This shell is read/write. Any changes you make affect")
-              << '\n'
-              << warning_line("the in-progress job and may change the build result.") << '\n'
-              << "+------------------------------------------------------------------+"
-              << std::endl;
+    std::cerr
+        << "+------------------------------------------------------------------+\n"
+        << warning_line("Attached to the live sandbox for Wake job " + std::to_string(job_id))
+        << '\n'
+        << warning_line("Payload PID: " + std::to_string(*payload_pid) + "  CWD: " + cwd_display)
+        << '\n'
+        << warning_line("Host FUSE live workspace:") << '\n'
+        << warning_line(host_live_workspace) << '\n'
+        << warning_line("Tools unavailable in shell can be run using the host FUSE path") << '\n'
+        << warning_line("above.") << '\n'
+        << warning_line("") << '\n'
+        << warning_line("WARNING: This shell and the host FUSE workspace are read/write.") << '\n'
+        << warning_line("Any changes you make affect the in-progress job and may change") << '\n'
+        << warning_line("the build result.") << '\n'
+        << "+------------------------------------------------------------------+" << std::endl;
 
     execl(shell, shell, nullptr);
     std::cerr << "wake --attach: exec(" << shell << "): " << strerror(errno) << std::endl;

--- a/tools/wake/attach.cpp
+++ b/tools/wake/attach.cpp
@@ -214,8 +214,6 @@ int attach_job(Database &db, long job_id) {
         << '\n'
         << warning_line("Host FUSE live workspace:") << '\n'
         << warning_line(host_live_workspace) << '\n'
-        << warning_line("Tools unavailable in shell can be run using the host FUSE path") << '\n'
-        << warning_line("above.") << '\n'
         << warning_line("") << '\n'
         << warning_line("WARNING: This shell and the host FUSE workspace are read/write.") << '\n'
         << warning_line("Any changes you make affect the in-progress job and may change") << '\n'

--- a/tools/wake/attach.cpp
+++ b/tools/wake/attach.cpp
@@ -17,9 +17,9 @@
 
 #include "attach.h"
 
-#include <dirent.h>
+#ifdef __linux__
+
 #include <fcntl.h>
-#include <limits.h>
 #include <sched.h>
 #include <signal.h>
 #include <string.h>
@@ -28,10 +28,12 @@
 
 #include <cerrno>
 #include <cstdio>
-#include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -41,38 +43,34 @@ constexpr int kPayloadRetries = 40;
 constexpr int kPayloadRetryDelayUs = 50000;  // 50ms * 40 = 2s
 
 std::string read_comm(pid_t pid) {
-  FILE *f = fopen(("/proc/" + std::to_string(pid) + "/comm").c_str(), "r");
-  if (!f) return "";
-  char buf[64] = {};
-  if (!fgets(buf, sizeof(buf), f)) buf[0] = 0;
-  fclose(f);
-  std::string comm(buf);
-  while (!comm.empty() && comm.back() == '\n') comm.pop_back();
+  std::ifstream comm_file("/proc/" + std::to_string(pid) + "/comm");
+  std::string comm;
+  std::getline(comm_file, comm);
   return comm;
 }
 
-// Parses ppid (field 4) out of /proc/<pid>/stat, skipping past the "(comm)"
-// field by scanning to the last ')' -- comm can itself contain spaces/parens.
-std::optional<pid_t> read_ppid(pid_t pid) {
-  FILE *f = fopen(("/proc/" + std::to_string(pid) + "/stat").c_str(), "r");
-  if (!f) return std::nullopt;
-  char buf[4096];
-  size_t n = fread(buf, 1, sizeof(buf) - 1, f);
-  fclose(f);
-  buf[n] = 0;
-
-  char *rparen = strrchr(buf, ')');
-  int ppid = 0;
-  if (!rparen || sscanf(rparen + 1, " %*c %d", &ppid) != 1) return std::nullopt;
-  return ppid;
+std::vector<pid_t> read_children(pid_t pid) {
+  std::ifstream children("/proc/" + std::to_string(pid) + "/task/" + std::to_string(pid) +
+                         "/children");
+  std::vector<pid_t> result;
+  pid_t child;
+  while (children >> child) result.push_back(child);
+  return result;
 }
 
 std::optional<std::string> read_ns_link(pid_t pid, const char *ns) {
-  std::string path = "/proc/" + std::to_string(pid) + "/ns/" + ns;
-  char buf[256];
-  ssize_t n = readlink(path.c_str(), buf, sizeof(buf) - 1);
-  if (n < 0) return std::nullopt;
-  return std::string(buf, n);
+  std::error_code error;
+  std::filesystem::path link =
+      std::filesystem::read_symlink("/proc/" + std::to_string(pid) + "/ns/" + ns, error);
+  if (error) return std::nullopt;
+  return link.string();
+}
+
+// unshare(CLONE_NEWUSER) leaves uid_map empty until wakebox writes the mapping.
+// Entering earlier gives the attached shell overflow (nobody) credentials.
+bool user_namespace_ready(pid_t pid) {
+  std::ifstream uid_map("/proc/" + std::to_string(pid) + "/uid_map");
+  return uid_map.peek() != std::ifstream::traits_type::eof();
 }
 
 // Find the direct child of `wakebox_main_pid` that has entered its own mount
@@ -80,38 +78,20 @@ std::optional<std::string> read_ns_link(pid_t pid, const char *ns) {
 // the host mount namespace). Excludes the wb-timer sibling (only present when
 // a command timeout is configured), which never unshares and would otherwise
 // be mistaken for the payload. Retries briefly to cover the race where the
-// payload hasn't forked/unshared yet.
-//
-// This is the caller's own job, so /proc is fully visible; no privilege or
-// CAP_SYS_PTRACE is needed to read /proc/<pid>/ns/*.
+// payload hasn't forked/unshared yet or has not finished initializing its user
+// namespace.
 std::optional<pid_t> resolve_payload_pid(pid_t wakebox_main_pid) {
   auto main_mnt_ns = read_ns_link(wakebox_main_pid, "mnt");
   if (!main_mnt_ns) return std::nullopt;
 
   for (int attempt = 0; attempt < kPayloadRetries; ++attempt) {
-    DIR *proc = opendir("/proc");
-    if (!proc) return std::nullopt;
-
-    std::optional<pid_t> found;
-    struct dirent *entry;
-    while ((entry = readdir(proc)) != nullptr) {
-      char *end = nullptr;
-      long candidate = strtol(entry->d_name, &end, 10);
-      if (end == entry->d_name || *end != '\0' || candidate <= 0) continue;  // not a pid dir
-      pid_t candidate_pid = static_cast<pid_t>(candidate);
-
-      auto ppid = read_ppid(candidate_pid);
-      if (!ppid || *ppid != wakebox_main_pid) continue;
+    for (pid_t candidate_pid : read_children(wakebox_main_pid)) {
       if (read_comm(candidate_pid) == "wb-timer") continue;
 
       auto mnt_ns = read_ns_link(candidate_pid, "mnt");
-      if (mnt_ns && *mnt_ns != *main_mnt_ns) {
-        found = candidate_pid;
-        break;
-      }
+      if (mnt_ns && *mnt_ns != *main_mnt_ns && user_namespace_ready(candidate_pid))
+        return candidate_pid;
     }
-    closedir(proc);
-    if (found) return found;
     usleep(kPayloadRetryDelayUs);
   }
   return std::nullopt;
@@ -139,20 +119,24 @@ int attach_job(Database &db, long job_id) {
     return EXIT_FAILURE;
   }
 
-  // kill(pid, 0) with signal 0 only probes for existence/permission, it
-  // sends nothing. ESRCH means the pid is really gone (stale record from a
-  // crashed run). EPERM means it exists but belongs to another uid -- attach
-  // only supports the owning user (only the owner's euid satisfies the
-  // kernel's setns ownership check without privilege), so that's an error too.
+  if (!db.is_live_run(info->run_id)) {
+    std::cerr << "wake --attach: job " << job_id
+              << " is not currently running (its wake run is no longer live)" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Signal 0 does not kill anything; it checks that the live job's process
+  // still exists and is accessible. errno is meaningful only if it fails.
   if (kill(info->pid, 0) != 0) {
     if (errno == ESRCH) {
-      std::cerr << "wake --attach: job " << job_id
-                << "'s process is no longer running (stale record from a crashed run -- run "
-                   "'wake' or 'wake --clean' to reap it)"
+      std::cerr << "wake --attach: job " << job_id << "'s process is no longer running"
                 << std::endl;
-    } else {
+    } else if (errno == EPERM) {
       std::cerr << "wake --attach: job " << job_id
                 << " belongs to another user; attach only supports jobs you launched" << std::endl;
+    } else {
+      std::cerr << "wake --attach: could not probe job " << job_id
+                << "'s process: " << strerror(errno) << std::endl;
     }
     return EXIT_FAILURE;
   }
@@ -164,7 +148,7 @@ int attach_job(Database &db, long job_id) {
   if (!payload_pid) {
     std::cerr << "wake --attach: could not find a sandboxed process for job " << job_id
               << " -- it may not have been run under the FUSE sandbox runner, or the sandbox "
-                 "hasn't started yet"
+                 "hasn't finished initializing yet"
               << std::endl;
     return EXIT_FAILURE;
   }
@@ -172,13 +156,8 @@ int attach_job(Database &db, long job_id) {
   const char *shell = getenv("SHELL");
   if (!shell || !*shell) shell = "/bin/sh";
 
-  // fork(): the child is single-threaded regardless of how many threads wake
-  // has, which is exactly what setns(CLONE_NEWUSER) requires. No privileged
-  // helper is needed -- the caller owns the job, so its euid matches the
-  // sandbox's user-namespace owner and the kernel permits the setns with no
-  // capabilities at all. The view is read/write (writes land in the same FUSE
-  // staging the job itself writes to); guaranteeing read-only would require
-  // CAP_SYS_ADMIN the owner doesn't have here (see the design doc's revision).
+  // setns(CLONE_NEWUSER) requires a single-threaded process, so enter the
+  // namespaces from a forked child. The attached view is read/write.
   pid_t child = fork();
   if (child < 0) {
     std::cerr << "wake --attach: fork: " << strerror(errno) << std::endl;
@@ -189,17 +168,11 @@ int attach_job(Database &db, long job_id) {
     std::string ns_dir = "/proc/" + std::to_string(*payload_pid) + "/ns/";
     std::string cwd_link = "/proc/" + std::to_string(*payload_pid) + "/cwd";
 
-    // Grab the job's working directory as an fd *before* entering the sandbox.
-    // The workspace can be mounted at an arbitrary path inside the sandbox
-    // (e.g. /workspace under a container rootfs, not the host workspace path),
-    // so a guessed absolute path is wrong in general. /proc/<payload>/cwd is a
-    // magic symlink the kernel resolves straight to the job's cwd dentry --
-    // openable here even though that path isn't reachable from our mount ns --
-    // and fchdir()ing it after setns lands us exactly where the job is. Also
-    // read its path string (as seen inside the sandbox) purely for the notice.
-    char cwd_path[PATH_MAX];
-    ssize_t n = readlink(cwd_link.c_str(), cwd_path, sizeof(cwd_path) - 1);
-    std::string cwd_display = n > 0 ? std::string(cwd_path, n) : "the job's working directory";
+    // Keep the job's cwd open before changing mount namespaces, then restore it
+    // with fchdir() after entering the sandbox. Read its path for the notice.
+    std::error_code error;
+    std::filesystem::path cwd_path = std::filesystem::read_symlink(cwd_link, error);
+    std::string cwd_display = error ? "the job's working directory" : cwd_path.string();
     int cwd_fd = open(cwd_link.c_str(), O_RDONLY | O_DIRECTORY);
     if (cwd_fd < 0) {
       std::cerr << "wake --attach: open(" << cwd_link << "): " << strerror(errno) << std::endl;
@@ -220,9 +193,14 @@ int attach_job(Database &db, long job_id) {
     }
     close(cwd_fd);
 
-    std::cerr << "wake --attach: read/write shell in the live sandbox of job " << job_id
-              << " (pid " << *payload_pid << ", cwd " << cwd_display
-              << "); writes go to the job's in-progress outputs" << std::endl;
+    std::cerr << "+------------------------------------------------------------------+\n"
+              << "| Attached to the live sandbox for Wake job " << job_id << "\n"
+              << "| PID: " << *payload_pid << "  CWD: " << cwd_display << "\n"
+              << "|                                                                  |\n"
+              << "| WARNING: This shell is read/write. Any changes you make affect   |\n"
+              << "| the in-progress job and may change the build result.             |\n"
+              << "+------------------------------------------------------------------+"
+              << std::endl;
 
     execl(shell, shell, nullptr);
     std::cerr << "wake --attach: exec(" << shell << "): " << strerror(errno) << std::endl;
@@ -236,3 +214,5 @@ int attach_job(Database &db, long job_id) {
   }
   return WIFEXITED(status) ? WEXITSTATUS(status) : EXIT_FAILURE;
 }
+
+#endif  // __linux__

--- a/tools/wake/attach.cpp
+++ b/tools/wake/attach.cpp
@@ -41,6 +41,15 @@ namespace {
 // namespaces (there's a short window right after wakebox forks it).
 constexpr int kPayloadRetries = 40;
 constexpr int kPayloadRetryDelayUs = 50000;  // 50ms * 40 = 2s
+constexpr size_t kWarningContentWidth = 64;
+
+std::string warning_line(std::string content) {
+  if (content.size() > kWarningContentWidth) {
+    content.resize(kWarningContentWidth - 3);
+    content += "...";
+  }
+  return "| " + content + std::string(kWarningContentWidth - content.size(), ' ') + " |";
+}
 
 std::string read_comm(pid_t pid) {
   std::ifstream comm_file("/proc/" + std::to_string(pid) + "/comm");
@@ -194,11 +203,14 @@ int attach_job(Database &db, long job_id) {
     close(cwd_fd);
 
     std::cerr << "+------------------------------------------------------------------+\n"
-              << "| Attached to the live sandbox for Wake job " << job_id << "\n"
-              << "| PID: " << *payload_pid << "  CWD: " << cwd_display << "\n"
-              << "|                                                                  |\n"
-              << "| WARNING: This shell is read/write. Any changes you make affect   |\n"
-              << "| the in-progress job and may change the build result.             |\n"
+              << warning_line("Attached to the live sandbox for Wake job " + std::to_string(job_id))
+              << '\n'
+              << warning_line("PID: " + std::to_string(*payload_pid) + "  CWD: " + cwd_display)
+              << '\n'
+              << warning_line("") << '\n'
+              << warning_line("WARNING: This shell is read/write. Any changes you make affect")
+              << '\n'
+              << warning_line("the in-progress job and may change the build result.") << '\n'
               << "+------------------------------------------------------------------+"
               << std::endl;
 

--- a/tools/wake/attach.h
+++ b/tools/wake/attach.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 SiFive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You should have received a copy of LICENSE.Apache2 along with
+ * this software. If not, you may obtain a copy at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ATTACH_H
+#define ATTACH_H
+
+#include "runtime/database.h"
+
+// Attach a read/write shell to the live FUSE sandbox of a still-running job.
+//
+// Linux only, and only for jobs the calling user launched: it works entirely
+// unprivileged (no helper, no capabilities) by fork()ing a single-threaded
+// child that setns() into the job's own user+mount namespaces, which the
+// kernel permits because the caller's euid owns those namespaces. The view is
+// read/write -- a kernel-enforced read-only view would need CAP_SYS_ADMIN the
+// owner doesn't have; see the design doc revision for why that was abandoned.
+// Filesystem view only (no pid-namespace/process interaction). Returns the
+// attached shell's exit status, or EXIT_FAILURE on error, for easy CLI use.
+int attach_job(Database &db, long job_id);
+
+#endif

--- a/tools/wake/attach.h
+++ b/tools/wake/attach.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 SiFive, Inc.
+ * Copyright 2026 SiFive, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/wake/attach.h
+++ b/tools/wake/attach.h
@@ -20,16 +20,8 @@
 
 #include "runtime/database.h"
 
-// Attach a read/write shell to the live FUSE sandbox of a still-running job.
-//
-// Linux only, and only for jobs the calling user launched: it works entirely
-// unprivileged (no helper, no capabilities) by fork()ing a single-threaded
-// child that setns() into the job's own user+mount namespaces, which the
-// kernel permits because the caller's euid owns those namespaces. The view is
-// read/write -- a kernel-enforced read-only view would need CAP_SYS_ADMIN the
-// owner doesn't have; see the design doc revision for why that was abandoned.
-// Filesystem view only (no pid-namespace/process interaction). Returns the
-// attached shell's exit status, or EXIT_FAILURE on error, for easy CLI use.
+// Attach a read/write shell to a running job's FUSE sandbox.
+// Returns the shell's exit status, or EXIT_FAILURE on error.
 int attach_job(Database &db, long job_id);
 
 #endif

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -42,6 +42,7 @@ struct CommandLineOptions {
   bool last_exe;
   bool history;
   bool ps;
+  bool attach;
   bool active;
   bool lsp;
   bool failed;
@@ -148,6 +149,7 @@ struct CommandLineOptions {
       {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
       {0, "history", GOPT_ARGUMENT_FORBIDDEN},
       {0, "ps", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "attach", GOPT_ARGUMENT_FORBIDDEN},
       {0, "active", GOPT_ARGUMENT_FORBIDDEN},
       {0, "queued", GOPT_ARGUMENT_FORBIDDEN},
       {0, "in-flight", GOPT_ARGUMENT_FORBIDDEN},
@@ -217,6 +219,7 @@ struct CommandLineOptions {
     last_exe = arg(options, "last-executed")->count;
     history = arg(options, "history")->count;
     ps = arg(options, "ps")->count;
+    attach = arg(options, "attach")->count;
     active = arg(options, "active")->count;
     queued = arg(options, "queued")->count;
     in_flight = arg(options, "in-flight")->count;
@@ -341,6 +344,14 @@ struct CommandLineOptions {
   std::optional<std::string> validate() {
     if (quiet && verbose) {
       return std::optional<std::string>{"Cannot specify both -v and -q!"};
+    }
+
+    if (attach) {
+      size_t num_ids = 0;
+      for (const auto &group : job_ids) num_ids += group.size();
+      if (num_ids != 1) {
+        return std::optional<std::string>{"--attach requires exactly one --job <id>!"};
+      }
     }
 
     if (profile && !debug) {

--- a/tools/wake/cli_options.h
+++ b/tools/wake/cli_options.h
@@ -98,6 +98,7 @@ struct CommandLineOptions {
   const char *label_filter;  // TODO: Allow unions of multiple filters
   const char *log_header;
   const char *user_config;
+  const char *attach_job_id;
 
   std::optional<int64_t> log_header_source_width;
 
@@ -149,7 +150,7 @@ struct CommandLineOptions {
       {0, "last-executed", GOPT_ARGUMENT_FORBIDDEN},
       {0, "history", GOPT_ARGUMENT_FORBIDDEN},
       {0, "ps", GOPT_ARGUMENT_FORBIDDEN},
-      {0, "attach", GOPT_ARGUMENT_FORBIDDEN},
+      {0, "attach", GOPT_ARGUMENT_REQUIRED},
       {0, "active", GOPT_ARGUMENT_FORBIDDEN},
       {0, "queued", GOPT_ARGUMENT_FORBIDDEN},
       {0, "in-flight", GOPT_ARGUMENT_FORBIDDEN},
@@ -273,6 +274,7 @@ struct CommandLineOptions {
     label_filter = arg(options, "label-filter")->argument;
     log_header = arg(options, "log-header")->argument;
     user_config = arg(options, "user-config")->argument;
+    attach_job_id = arg(options, "attach")->argument;
 
     if (arg(options, "log-header-align")->count) {
       log_header_align = std::make_optional(true);
@@ -347,10 +349,8 @@ struct CommandLineOptions {
     }
 
     if (attach) {
-      size_t num_ids = 0;
-      for (const auto &group : job_ids) num_ids += group.size();
-      if (num_ids != 1) {
-        return std::optional<std::string>{"--attach requires exactly one --job <id>!"};
+      if (!job_ids.empty()) {
+        return std::optional<std::string>{"--attach takes a job id directly; do not use --job!"};
       }
     }
 

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -46,6 +46,7 @@
 #include <set>
 #include <sstream>
 
+#include "attach.h"
 #include "clean.h"
 #include "cli_options.h"
 #include "describe.h"
@@ -432,6 +433,7 @@ void print_help(const char *argv0) {
     << "    --last-executed    Capture all jobs executed by the last build. Skips cache"   << std::endl
     << "    --history          Report the cmndline history of all wake commands recorded"  << std::endl
     << "    --ps               Show jobs currently running in active wake builds"          << std::endl
+    << "    --attach           With --job JOB, attach a shell to its live sandbox (Linux only)"      << std::endl
     << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
     << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
     << "    --canceled         Capture jobs which were canceled (run ended before job finished)" << std::endl
@@ -957,6 +959,21 @@ int main(int argc, char **argv) {
   }
 
   if (is_db_inspection) {
+    if (clo.attach) {
+#if defined(__linux__)
+      long job_id;
+      try {
+        job_id = std::stol(clo.job_ids[0][0]);
+      } catch (const std::exception &) {
+        std::cerr << "wake --attach: invalid job id '" << clo.job_ids[0][0] << "'" << std::endl;
+        return 1;
+      }
+      return attach_job(db, job_id);
+#else
+      std::cerr << "wake --attach: only supported on Linux." << std::endl;
+      return 1;
+#endif
+    }
     inspect_database(clo, db);
     return 0;
   }

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -433,7 +433,7 @@ void print_help(const char *argv0) {
     << "    --last-executed    Capture all jobs executed by the last build. Skips cache"   << std::endl
     << "    --history          Report the cmndline history of all wake commands recorded"  << std::endl
     << "    --ps               Show jobs currently running in active wake builds"          << std::endl
-    << "    --attach           With --job JOB, attach a shell to its live FUSE sandbox"    << std::endl
+    << "    --attach     JOB   Attach a shell to the specified job ID's live FUSE sandbox" << std::endl
     << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
     << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
     << "    --canceled         Capture jobs which were canceled (run ended before job finished)" << std::endl
@@ -641,10 +641,10 @@ int main(int argc, char **argv) {
   }
 
   bool is_db_inspect_capture = !clo.job_ids.empty() || !clo.output_files.empty() ||
-                               !clo.input_files.empty() || !clo.labels.empty() ||
-                               !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
-                               clo.tagdag || clo.canceled || clo.active || clo.queued ||
-                               clo.in_flight || clo.history || clo.ps;
+                                !clo.input_files.empty() || !clo.labels.empty() ||
+                                !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
+                                clo.tagdag || clo.canceled || clo.active || clo.queued ||
+                                clo.in_flight || clo.history || clo.ps || clo.attach;
 
   // DescribePolicy::human() is the default and doesn't have a flag.
   // DescribePolicy::debug() is overloaded and can't be marked as a db flag
@@ -963,9 +963,9 @@ int main(int argc, char **argv) {
 #if defined(__linux__)
       long job_id;
       try {
-        job_id = std::stol(clo.job_ids[0][0]);
+        job_id = std::stol(clo.attach_job_id);
       } catch (const std::exception &) {
-        std::cerr << "wake --attach: invalid job id '" << clo.job_ids[0][0] << "'" << std::endl;
+        std::cerr << "wake --attach: invalid job id '" << clo.attach_job_id << "'" << std::endl;
         return 1;
       }
       return attach_job(db, job_id);

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -641,10 +641,10 @@ int main(int argc, char **argv) {
   }
 
   bool is_db_inspect_capture = !clo.job_ids.empty() || !clo.output_files.empty() ||
-                                !clo.input_files.empty() || !clo.labels.empty() ||
-                                !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
-                                clo.tagdag || clo.canceled || clo.active || clo.queued ||
-                                clo.in_flight || clo.history || clo.ps || clo.attach;
+                               !clo.input_files.empty() || !clo.labels.empty() ||
+                               !clo.tags.empty() || clo.last_use || clo.last_exe || clo.failed ||
+                               clo.tagdag || clo.canceled || clo.active || clo.queued ||
+                               clo.in_flight || clo.history || clo.ps || clo.attach;
 
   // DescribePolicy::human() is the default and doesn't have a flag.
   // DescribePolicy::debug() is overloaded and can't be marked as a db flag

--- a/tools/wake/main.cpp
+++ b/tools/wake/main.cpp
@@ -433,7 +433,7 @@ void print_help(const char *argv0) {
     << "    --last-executed    Capture all jobs executed by the last build. Skips cache"   << std::endl
     << "    --history          Report the cmndline history of all wake commands recorded"  << std::endl
     << "    --ps               Show jobs currently running in active wake builds"          << std::endl
-    << "    --attach           With --job JOB, attach a shell to its live sandbox (Linux only)"      << std::endl
+    << "    --attach           With --job JOB, attach a shell to its live FUSE sandbox"    << std::endl
     << "    --failed   -f      Capture jobs which failed last build"                       << std::endl
     << "    --tag      KEY=VAL Capture jobs which are tagged, matching KEY and VAL globs"  << std::endl
     << "    --canceled         Capture jobs which were canceled (run ended before job finished)" << std::endl


### PR DESCRIPTION
This PR adds `wake --attach JOBID`, which opens a shell in a live FUSE-sandboxed Wake job. This lets users inspect the job's in-progress outputs through its virtualized workspace view. It also prints out the live FUSE workspace path, giving options to users to use external tools against that fuse path.

It adds a `live_jobs` table that records the active job's Wake run and wakebox-main PID. Attach uses that PID to find the wakebox payload child, which owns the sandbox's user and mount namespaces. A forked attach child joins those namespaces, restores the job's working directory, and execs the user's shell.

The attached shell and printed out fuse path is read/write, so changes affect the in-progress job and may change the build result.