### PR TITLE
RSC decode db-scheme content directly

### DIFF
--- a/share/wake/lib/system/cas.wake
+++ b/share/wake/lib/system/cas.wake
@@ -56,6 +56,11 @@ def primCasIngestStagedItem (destPath: String) (itemType: String) (stagingPathOr
     raw destPath itemType stagingPathOrTarget hash
     | rmapError makeError
 
+# Store inline content in CAS under its already-verified hash.
+export def ingestStringIntoCas (destPath: String) (content: String) (hash: String): Result Unit Error =
+    primCasIngestStagedItem destPath "string" content hash
+    | addErrorContext "Ingesting inline content for {destPath}"
+
 # Materialize a staged item directly into the workspace without hashing it or storing it in CAS.
 def primMaterializeStagedWorkspaceItem (destPath: String) (itemType: String) (stagingPathOrTarget: String) (mode: Integer) (mtimeSec: Integer) (mtimeNsec: Integer): Result Unit Error =
     def raw destPath itemType stagingPathOrTarget mode mtimeSec mtimeNsec =

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -643,10 +643,16 @@ def chunkList (n: Integer) (xs: List a): List (List a) =
 
     head, chunkList n tail
 
-# resolveBlobsToPaths: Resolves many blobs to local file paths holding their bytes. db-scheme blobs
-# are decoded inline (no network); file/http(s) blobs are downloaded via few batched curl jobs. Blobs
-# are deduped by id so shared content is only fetched once. Returns an assoc list of (blobId -> Path).
-def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String Path)) Error =
+# Either: Holds one of two possible values.
+data Either a b =
+    Left a
+    Right b
+
+# resolveBlobsToPathsOrStrings: Resolves many blobs to local file paths or inline strings. db-scheme
+# blobs are decoded inline (no network); file/http(s) blobs are downloaded via few batched curl jobs.
+# Blobs are deduped by id so shared content is only fetched once. Returns an assoc list of
+# (blobId -> Either Path String).
+def resolveBlobsToPathsOrStrings (blobs: List CacheSearchBlob): Result (List (Pair String (Either Path String))) Error =
     # Dedupe by blob id: identical ids resolve to identical bytes, so fetch each once.
     def uniqueBlobs =
         blobs
@@ -677,13 +683,11 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
         parsedBlobs
         | splitBy (\(Pair _ (Pair scheme _)) scheme ==* "db")
 
-    # Resolve db-scheme blobs inline to temp files (no curl), reusing the already-parsed scheme/path.
-    def resolveDbBlob ((Pair blob (Pair scheme path)): Pair CacheSearchBlob (Pair String String)): Result (Pair String Path) Error =
-        require Pass tmp =
-            resolveDbScheme scheme path
-            |> writeTempFile "rsc.blob.{blob.getCacheSearchBlobId}"
+    # Decode db-scheme blobs inline rather than materializing tracked temporary files.
+    def resolveDbBlob ((Pair blob (Pair scheme path)): Pair CacheSearchBlob (Pair String String)): Result (Pair String (Either Path String)) Error =
+        require Pass content = resolveDbScheme scheme path
 
-        Pass (Pair blob.getCacheSearchBlobId tmp)
+        Pass (Pair blob.getCacheSearchBlobId (Right content))
 
     require Pass dbResolved =
         dbParsed
@@ -698,7 +702,7 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
     def wakePid: Integer = prim "pid"
     def httpDir = ".build/wake-{str wakePid}/stdlib/http"
 
-    def downloadChunk (chunk: List CacheSearchBlob): Result (List (Pair String Path)) Error =
+    def downloadChunk (chunk: List CacheSearchBlob): Result (List (Pair String (Either Path String))) Error =
         # Sort the chunk deterministically by blob id so that two batches with the same blob set
         # produce byte-identical curl jobs (which wake then dedups to a single job / single writer).
         def sortedChunk =
@@ -731,7 +735,7 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
         sortedChunk
         | map (
             \b match (mlookup (destForBlob b) pathByName)
-                Some p -> Pass (Pair b.getCacheSearchBlobId p)
+                Some p -> Pass (Pair b.getCacheSearchBlobId (Left p))
                 None ->
                     failWithError "rsc: batched download did not produce output for blob {b.getCacheSearchBlobId}"
         )
@@ -749,33 +753,20 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
 # rscApiGetStringBlobs: Batched analogue of rscApiGetStringBlob. Downloads many blobs, verifies each
 # blob's content hash, and returns the contents in the same order as the input.
 export def rscApiGetStringBlobs (blobs: List CacheSearchBlob): Result (List String) Error =
-    def isDbSchemeBlob (blob: CacheSearchBlob): Boolean =
-        matches `db://.*` blob.getCacheSearchBlobUri
+    require Pass resolved = resolveBlobsToPathsOrStrings blobs
 
-    # Decode db-scheme blob content directly rather than materializing a tracked temporary file.
-    # Routing them through writeTempFile causes
-    # concurrent cache hits for identical stdout/stderr to share a tracked path,
-    # which can disappear while another rehydration is still reading it.
-    def networkBlobs = filter (! isDbSchemeBlob _) blobs
-
-    require Pass resolved = resolveBlobsToPaths networkBlobs
-
-    def pathById =
+    def contentById =
         resolved
         | listToMap scmp
 
     def resolveOne ((CacheSearchBlob blobId _uri contentHash): CacheSearchBlob): Result String Error =
         require Pass content =
-            require (scheme, path, Nil) = extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` _uri
-            else failWithError "rsc: uri has unexpected format: '{_uri}'"
+            require Some resolvedContent = mlookup blobId contentById
+            else failWithError "rsc: no downloaded bytes found for blob {blobId}"
 
-            if scheme ==* "db" then
-                resolveDbScheme scheme path
-            else
-                require Some blobPath = mlookup blobId pathById
-                else failWithError "rsc: no downloaded bytes found for blob {blobId}"
-
-                read blobPath
+            match resolvedContent
+                Left blobPath -> read blobPath
+                Right inlineContent -> Pass inlineContent
 
         def actualHash = hashString content
 
@@ -808,15 +799,20 @@ export def rscApiGetBlobsToCas (entries: List (Pair CacheSearchBlob (Pair String
         entries
         | map getPairFirst
 
-    require Pass resolved = resolveBlobsToPaths blobs
+    require Pass resolved = resolveBlobsToPathsOrStrings blobs
 
-    def pathById =
+    def contentById =
         resolved
         | listToMap scmp
 
     def prepareOne ((Pair (CacheSearchBlob blobId _uri contentHash) (Pair path mode)): Pair CacheSearchBlob (Pair String Integer)): Result PreparedStagingItem Error =
-        require Some blobPath = mlookup blobId pathById
+        require Some resolvedContent = mlookup blobId contentById
         else failWithError "rsc: no downloaded bytes found for blob {blobId}"
+
+        require Pass blobPath = match resolvedContent
+            Left downloadedPath -> Pass downloadedPath
+            # CAS ingestion needs a path, unlike the stdout/stderr string consumer above.
+            Right inlineContent -> writeTempFile "rsc.blob.{blobId}" inlineContent
 
         def actualHash = blobPath.getPathHash
 

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -792,7 +792,8 @@ export def rscApiGetStringBlob (blob: CacheSearchBlob): Result String Error =
     Pass content
 
 # rscApiGetBlobsToCas: Batched analogue of rscApiGetFileBlobToCas. Downloads many file blobs,
-# verifies each blob's hash, and ingests each into CAS. Returns the PreparedStagingItems
+# verifies each blob's hash, and ingests each into CAS. Inline blob content is stored directly in
+# CAS rather than being written to a temporary file. Returns the PreparedStagingItems
 # (in input order) so the caller can materialize them later, after every blob for a job has been verified.
 export def rscApiGetBlobsToCas (entries: List (Pair CacheSearchBlob (Pair String Integer))): Result (List PreparedStagingItem) Error =
     def blobs =
@@ -809,24 +810,31 @@ export def rscApiGetBlobsToCas (entries: List (Pair CacheSearchBlob (Pair String
         require Some resolvedContent = mlookup blobId contentById
         else failWithError "rsc: no downloaded bytes found for blob {blobId}"
 
-        require Pass blobPath = match resolvedContent
-            Left downloadedPath -> Pass downloadedPath
-            # CAS ingestion needs a path, unlike the stdout/stderr string consumer above.
-            Right inlineContent -> writeTempFile "rsc.blob.{blobId}" inlineContent
-
-        def actualHash = blobPath.getPathHash
+        def actualHash = match resolvedContent
+            Left downloadedPath -> downloadedPath.getPathHash
+            Right inlineContent -> hashString inlineContent
 
         require Pass _ = verifyBlobHash blobId actualHash contentHash
 
-        # Build a synthetic PreparedStagingItem from the staging path under ".build/wake-{pid}/...".
-        # That path will be ingested and reflink/copy'd into CAS.
-        def preparedItem =
-            PreparedStagingItem
-            (StagingFile (StagingFileOutput path blobPath.getPathName mode 0 0)) # use 0 for mtime; This will be set to the current time on materialization.
-            contentHash
+        # Use 0 for mtime; this is set to the current time on materialization. The staging path is
+        # not needed after CAS ingestion, so inline blobs use their destination as a placeholder.
+        require Pass preparedItem = match resolvedContent
+            Left downloadedPath ->
+                PreparedStagingItem
+                (StagingFile (StagingFileOutput path downloadedPath.getPathName mode 0 0))
+                contentHash
+                | Pass
+            Right inlineContent ->
+                require Pass _ = ingestStringIntoCas path inlineContent contentHash
+
+                Pass (PreparedStagingItem (StagingFile (StagingFileOutput path path mode 0 0)) contentHash)
+
+        def ingestPrepared = match resolvedContent
+            Left _ -> ingestPreparedStagingItemIntoCas preparedItem
+            Right _ -> Pass Unit
 
         require Pass _ =
-            ingestPreparedStagingItemIntoCas preparedItem
+            ingestPrepared
             | addErrorContext "rsc: Failed to ingest blob {blobId} into CAS for {path}"
 
         Pass preparedItem

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -749,17 +749,33 @@ def resolveBlobsToPaths (blobs: List CacheSearchBlob): Result (List (Pair String
 # rscApiGetStringBlobs: Batched analogue of rscApiGetStringBlob. Downloads many blobs, verifies each
 # blob's content hash, and returns the contents in the same order as the input.
 export def rscApiGetStringBlobs (blobs: List CacheSearchBlob): Result (List String) Error =
-    require Pass resolved = resolveBlobsToPaths blobs
+    def isDbSchemeBlob (blob: CacheSearchBlob): Boolean =
+        matches `db://.*` blob.getCacheSearchBlobUri
+
+    # Decode db-scheme blob content directly rather than materializing a tracked temporary file.
+    # Routing them through writeTempFile causes
+    # concurrent cache hits for identical stdout/stderr to share a tracked path,
+    # which can disappear while another rehydration is still reading it.
+    def networkBlobs = filter (! isDbSchemeBlob _) blobs
+
+    require Pass resolved = resolveBlobsToPaths networkBlobs
 
     def pathById =
         resolved
         | listToMap scmp
 
     def resolveOne ((CacheSearchBlob blobId _uri contentHash): CacheSearchBlob): Result String Error =
-        require Some blobPath = mlookup blobId pathById
-        else failWithError "rsc: no downloaded bytes found for blob {blobId}"
+        require Pass content =
+            require (scheme, path, Nil) = extract `([a-zA-Z][a-zA-Z0-9+.-]*)://(.*)` _uri
+            else failWithError "rsc: uri has unexpected format: '{_uri}'"
 
-        require Pass content = read blobPath
+            if scheme ==* "db" then
+                resolveDbScheme scheme path
+            else
+                require Some blobPath = mlookup blobId pathById
+                else failWithError "rsc: no downloaded bytes found for blob {blobId}"
+
+                read blobPath
 
         def actualHash = hashString content
 
@@ -1289,4 +1305,3 @@ def mkCacheSearchResponse (json: JValue): Result CacheSearchResponse Error =
     obytes
     | Match
     | Pass
-

--- a/share/wake/lib/system/remote_cache_api.wake
+++ b/share/wake/lib/system/remote_cache_api.wake
@@ -810,31 +810,21 @@ export def rscApiGetBlobsToCas (entries: List (Pair CacheSearchBlob (Pair String
         require Some resolvedContent = mlookup blobId contentById
         else failWithError "rsc: no downloaded bytes found for blob {blobId}"
 
-        def actualHash = match resolvedContent
-            Left downloadedPath -> downloadedPath.getPathHash
-            Right inlineContent -> hashString inlineContent
+        def Pair actualHash stagingPath = match resolvedContent
+            Left downloadedPath -> Pair downloadedPath.getPathHash downloadedPath.getPathName
+            Right inlineContent -> Pair (hashString inlineContent) path
 
         require Pass _ = verifyBlobHash blobId actualHash contentHash
 
-        # Use 0 for mtime; this is set to the current time on materialization. The staging path is
-        # not needed after CAS ingestion, so inline blobs use their destination as a placeholder.
-        require Pass preparedItem = match resolvedContent
-            Left downloadedPath ->
-                PreparedStagingItem
-                (StagingFile (StagingFileOutput path downloadedPath.getPathName mode 0 0))
-                contentHash
-                | Pass
-            Right inlineContent ->
-                require Pass _ = ingestStringIntoCas path inlineContent contentHash
-
-                Pass (PreparedStagingItem (StagingFile (StagingFileOutput path path mode 0 0)) contentHash)
-
-        def ingestPrepared = match resolvedContent
-            Left _ -> ingestPreparedStagingItemIntoCas preparedItem
-            Right _ -> Pass Unit
+        # Use 0 for mtime; set to the current time on materialization. Inline blobs have no staging
+        # file, so they use their destination as the staging path (ignored by CAS materialization).
+        def preparedItem =
+            PreparedStagingItem (StagingFile (StagingFileOutput path stagingPath mode 0 0)) contentHash
 
         require Pass _ =
-            ingestPrepared
+            match resolvedContent
+                Left _ -> ingestPreparedStagingItemIntoCas preparedItem
+                Right inlineContent -> ingestStringIntoCas path inlineContent actualHash
             | addErrorContext "rsc: Failed to ingest blob {blobId} into CAS for {path}"
 
         Pass preparedItem

--- a/share/wake/lib/system/remote_cache_api_test.wake
+++ b/share/wake/lib/system/remote_cache_api_test.wake
@@ -2,6 +2,25 @@ package remote_cache
 
 from wake import _
 
+export def testInlineStringBlobDecoding Unit: Result Unit Error =
+    def content = "shared stdout"
+    def encoded =
+        content
+        | unicodeToBytes
+        | map (\byte ('%', strHex byte, Nil) | cat)
+        | cat
+    def blob = CacheSearchBlob "shared" "db://{encoded}" (hashString content)
+
+    require Pass values = rscApiGetStringBlobs (blob, blob, Nil)
+
+    require (actual1, actual2, Nil) = values
+    else failWithError "Expected exactly two decoded inline blobs"
+
+    require True = actual1 ==* content && actual2 ==* content
+    else failWithError "Inline string blobs did not decode to expected content"
+
+    Pass Unit
+
 export def testDisablingCacheWithEndpoints (api: RemoteCacheApi): Result Unit Error =
     def testDisableCache Unit: Result Unit Error =
         require Pass _ = disableRemoteCache Unit
@@ -77,6 +96,8 @@ export def testDisablingCacheWithEndpoints (api: RemoteCacheApi): Result Unit Er
         Pass Unit
 
     def runTests Unit: Result Unit Error =
+        require Pass _ = testInlineStringBlobDecoding Unit
+
         # First Disable Cache
         require Pass _ = testDisableCache Unit
 

--- a/share/wake/lib/system/remote_cache_api_test.wake
+++ b/share/wake/lib/system/remote_cache_api_test.wake
@@ -4,11 +4,13 @@ from wake import _
 
 export def testInlineStringBlobDecoding Unit: Result Unit Error =
     def content = "shared stdout"
+
     def encoded =
         content
         | unicodeToBytes
         | map (\byte ('%', strHex byte, Nil) | cat)
         | cat
+
     def blob = CacheSearchBlob "shared" "db://{encoded}" (hashString content)
 
     require Pass values = rscApiGetStringBlobs (blob, blob, Nil)
@@ -18,6 +20,29 @@ export def testInlineStringBlobDecoding Unit: Result Unit Error =
 
     require True = actual1 ==* content && actual2 ==* content
     else failWithError "Inline string blobs did not decode to expected content"
+
+    Pass Unit
+
+export def testInlineFileBlobStaging Unit: Result Unit Error =
+    def content = "inline file"
+
+    def encoded =
+        content
+        | unicodeToBytes
+        | map (\byte ('%', strHex byte, Nil) | cat)
+        | cat
+
+    def blob = CacheSearchBlob "inline-file" "db://{encoded}" (hashString content)
+
+    require Pass preparedItems = rscApiGetBlobsToCas (Pair blob (Pair "test-inline-file" 0644), Nil)
+
+    require (PreparedStagingItem (StagingFile (StagingFileOutput path stagingPath mode 0 0)) hash, Nil) =
+        preparedItems
+    else failWithError "Expected inline file blob to be prepared for CAS materialization"
+
+    require True =
+        path ==* "test-inline-file" && stagingPath ==* path && mode == 0644 && hash ==* hashString content
+    else failWithError "Inline file staging item did not preserve metadata"
 
     Pass Unit
 
@@ -97,6 +122,7 @@ export def testDisablingCacheWithEndpoints (api: RemoteCacheApi): Result Unit Er
 
     def runTests Unit: Result Unit Error =
         require Pass _ = testInlineStringBlobDecoding Unit
+        require Pass _ = testInlineFileBlobStaging Unit
 
         # First Disable Cache
         require Pass _ = testDisableCache Unit

--- a/share/wake/lib/system/remote_cache_runner.wake
+++ b/share/wake/lib/system/remote_cache_runner.wake
@@ -294,7 +294,10 @@ export def mkRemoteCacheRunner (rscApi: RemoteCacheApi) (hashFn: RunnerInput => 
                 Pass x -> x
                 # Otherwise if hydration fails for any reason just run the job as normal.
                 # There is no point in attempting to push since the server just said its cached
-                Fail _ -> baseDoIt job input
+                Fail err ->
+                    def _ = breadcrumb "{label}: Failed to rehydrate cached job: {format err}"
+
+                    baseDoIt job input
 
         # Search the remote cache for the job
         match (rscApi | rscApiFindMatchingJob (mkSearchRequest input hashKey))

--- a/src/runtime/cas_prim.cpp
+++ b/src/runtime/cas_prim.cpp
@@ -429,6 +429,7 @@ static PRIMFN(prim_materialize_staged_workspace_item) {
 // prim "cas_ingest_staged_item" destPath type stagingPathOrTarget hash -> Result Unit Error
 // Stores staged content in CAS under its precomputed hash. Does not write to the workspace.
 // - type="file": stagingPathOrTarget = staging path
+// - type="string": stagingPathOrTarget = inline file contents
 // - type="symlink": stagingPathOrTarget = symlink target
 // - type="directory": no-op (directories have no CAS blob)
 static PRIMTYPE(type_cas_ingest_staged_item) {
@@ -490,6 +491,24 @@ static PRIMFN(prim_cas_ingest_staged_item) {
     }
 
     cleanup_staging_file(staging_path, dest_str);
+
+  } else if (type == "string") {
+    std::string content(staging_path_or_target->c_str(), staging_path_or_target->size());
+    cas::ContentHash expected_hash;
+    std::string parse_error;
+    if (!parse_hash_string(hash_str->c_str(), expected_hash, parse_error)) {
+      runtime.heap.reserve(reserve_result() + String::reserve(parse_error.size()));
+      auto err = String::claim(runtime.heap, parse_error);
+      RETURN(claim_result(runtime.heap, false, err));
+    }
+
+    auto store_result = store->store_blob_with_hash(content, expected_hash);
+    if (!store_result) {
+      std::string msg = "Failed to store inline staged file in CAS for " + dest_str;
+      runtime.heap.reserve(reserve_result() + String::reserve(msg.size()));
+      auto err = String::claim(runtime.heap, msg);
+      RETURN(claim_result(runtime.heap, false, err));
+    }
 
   } else if (type == "symlink") {
     // Handle symlink: insert the target bytes into CAS under the precomputed hash.


### PR DESCRIPTION
I noticed RSC cache hits that were failing to rehydrate. The added breadcrumb pointed me (and my best agent) to a race condition from identical stdout/stderr sharing a common path and the file being deleted while a later rehydration is trying to read it 

The error messages were of the form:
```
read .build/tmp/writes/rsc.blob...: No such file or directory
```

This is an attempt to avoid the issue by just reading the content directly in memory rather than writing it to a file.

A couple of things I'd like feedback on:
1. Is the performance of this okay using regular expressions? That's what `resolveBlobsToPaths` does.
2. I changed this just for `rscApiGetStringBlobs` (avoiding calling `resolveBlobsToPaths`) but not for the other caller which is `rscApiGetBlobsToCas`. Should that also be changed or should perhaps this logic be inlined into `resolveBlobsToPaths` (and obviously the function be changed to contemplate returning values of either `Path` or `String`)?